### PR TITLE
Pin networkx and tabulate (required by python-tsp)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,8 @@ scipy = ">=1.15.2,<2"
 numpy = ">=2.2.6,<3"
 h5py = ">=3.14.0,<4"
 area-detector-handlers = ">=0.0.10,<0.0.11"
+networkx = "~=2.1"  # FIXME: Required by python-tsp
+tabulate = "~=0.8.7"  # FIXME: Required by python-tsp
 
 [pypi-dependencies]
 xrt = ">=1.6.1,<2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
   "h5py",
   "area-detector-handlers",
   "bluesky-tiled-plugins",
+  "networkx~=2.1",  # FIXME: Required by python-tsp
+  "tabulate~=0.8.7",  # FIXME: Required by python-tsp
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
Before this change, doing the following shows inconsistency in requirements:
```
$ pixi add pip
$ pixi run pip check
tsplib95 0.7.1 has requirement networkx~=2.1, but you have networkx 3.5.
tsplib95 0.7.1 has requirement tabulate~=0.8.7, but you have tabulate 0.9.0.
```
So I am pinning networkx and tabulate for now. tsplib95 does not seem to be maintained anymore so maybe we should consider something else...

Found this while trying to add blop to conda-forge: https://github.com/conda-forge/staged-recipes/pull/31223