### PR TITLE
Protocols for optimization with Bluesky

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -7,3 +7,4 @@ API Reference
     reference/agent.rst
     reference/dof.rst
     reference/objective.rst
+    reference/protocols.rst

--- a/docs/source/reference/protocols.rst
+++ b/docs/source/reference/protocols.rst
@@ -1,0 +1,42 @@
+Protocols
+=========
+
+AcquisitionPlan
+---------------
+
+.. autoclass:: blop.protocols.AcquisitionPlan
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__
+   :no-index:
+
+EvaluationFunction
+------------------
+
+.. autoclass:: blop.protocols.EvaluationFunction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __call__
+
+Generator
+---------
+
+.. autoclass:: blop.protocols.Generator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:
+   :no-index:
+
+OptimizationProblem
+-------------------
+
+.. autoclass:: blop.protocols.OptimizationProblem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:
+   :no-index:

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -1,0 +1,128 @@
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+from bluesky.protocols import NamedMovable, Readable
+from bluesky.utils import MsgGenerator, plan
+
+NamedMovableT = TypeVar("NamedMovableT", bound=NamedMovable)
+
+
+@runtime_checkable
+class Generator(Protocol):
+    """
+    A minimal generator interface for optimization.
+    """
+
+    def suggest(self, num_points: int | None = None) -> list[dict]:
+        """
+        Returns a set of points in the input space, to be evaulated next.
+
+        The "_id" key is optional and can be used to identify suggested trials for later evaluation
+        and ingestion.
+
+        Parameters
+        ----------
+        num_points : int | None, optional
+            The number of points to suggest. If not provided, will default to 1.
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries, each containing a parameterization of a point to evaluate next.
+            Each dictionary must contain a unique "_id" key to identify each parameterization.
+        """
+        ...
+
+    def ingest(self, points: list[dict]) -> None:
+        """
+        Ingest a set of points into the experiment. Either from previously suggested points or from an external source.
+
+        The "_id" key is optional and can be used to identify points from previously suggested trials or to identify
+        the point as a "baseline" trial.
+
+        Parameters
+        ----------
+        points : list[dict]
+            A list of dictionaries, each containing the outcomes of each suggested parameterization.
+        """
+        ...
+
+
+@runtime_checkable
+class EvaluationFunction(Protocol):
+    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+        """
+        Evaluate the data from a Bluesky run and produce outcomes.
+
+        Parameters
+        ----------
+        uid: str
+            The unique identifier of the Bluesky run to evaluate.
+        suggestions: list[dict]
+            A list of dictionaries, each containing the parameterization of a point to evaluate.
+            The "_id" key is optional and can be used to identify each suggestion.
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries containing the outcomes of the run, one for each suggested parameterization.
+            The "_id" key is optional and can be used to identify each outcome.
+        """
+        ...
+
+
+@runtime_checkable
+class AcquisitionPlan(Protocol):
+    @plan
+    def __call__(
+        self,
+        movables: Mapping[NamedMovableT, Sequence[Any]],
+        readables: Sequence[Readable] | None = None,
+    ) -> MsgGenerator[str]:
+        """
+        Acquire data for optimization.
+
+        This should be a Bluesky plan that moves the movables to each of their suggested positions
+        and acquires data from the readables.
+
+        Parameters
+        ----------
+        movables: Mapping[NamedMovableT, Sequence[Any]]
+            The movables to move and the inputs to move them to.
+        readables: Sequence[Readable], optional
+            The readables that produce data to evaluate.
+
+        Returns
+        -------
+        str
+            The unique identifier of the Bluesky run.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class OptimizationProblem:
+    """
+    An optimization problem to solve. Immutable once initialized.
+
+    Attributes
+    ----------
+    generator: Generator
+        Suggests points to evaluate and ingests outcomes to inform the optimization.
+    movables: Sequence[NamedMovable]
+        Objects that can be moved to control the beamline using the Bluesky RunEngine.
+        A subset of the movables' names must match the names of suggested parameterizations.
+    readables: Sequence[Readable]
+        Objects that can be read to acquire data from the beamline using the Bluesky RunEngine.
+    evaluation_function: EvaluationFunction
+        A callable to evaluate data from a Bluesky run and produce outcomes.
+    acquisition_plan: AcquisitionPlan, optional
+        A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
+    """
+
+    generator: Generator
+    movables: Sequence[NamedMovable]
+    readables: Sequence[Readable]
+    evaluation_function: EvaluationFunction
+    acquisition_plan: AcquisitionPlan | None = None


### PR DESCRIPTION
# Blop Protocols

## Summary

Introduces standard protocols for interfacing between optimization backends, analysis routines, acquisition plans, and the Bluesky RunEngine.

Work toward resolving #178 

## Motivation

We want to decouple the different components of Blop to allow for both simplicity and full flexibility. By defining a standard set of protocols, we can more easily provide tools that beamline users can use out of the box to solve difficult beamline optimization problems.

## Components
- `blop.protocols.Generator`: a simple interface to an optimization backend (subset of [gest-api](https://github.com/campa-consortium/gest-api/blob/c6dd6360a6d91175c18e56763b8b96d7ae9d6e80/gest_api/generator.py#L5))
- `blop.protocols.EvaluationFunction`: replacement for `blop.data_access.DataAccess` and digestion function interfaces. Standardized to allow users to fully customize both data retrieval and analysis.
- `blop.protocols.AcquisitionPlan`: a callable object that is a Bluesky plan, used for customized acquisition.
- `blop.protocols.OptimizationProblem`: an immutable dataclass describing an optimization problem. Members must be immutable to ensure data consistency.

## What this enables

- Different optimization backends:
  - Ax (using Blop or otherwise)
  - Xopt
  - Any other [gest-api](https://github.com/campa-consortium/gest-api) generator
  - Custom optimizers
- Optimized fetching & data analysis
  - Before, we were pre-fetching all of the data from databroker/tiled (see #184 )
- Custom Bluesky plans
  - Before, you must use `agent.learn`. Now you don't need an `agent` at all.

## Future work

- Standard, optimization-focused, Bluesky plans (see https://github.com/NSLS-II/blop/tree/plan-separation for a proof-of-concept)
- Documentation (tutorials, how-to-guides, explanations)