### PR TITLE
Evaluation functions

### DIFF
--- a/src/blop/evaluation.py
+++ b/src/blop/evaluation.py
@@ -1,9 +1,9 @@
-from typing import cast, Literal
+from typing import Literal, cast
 
-from tiled.client.container import Container
 from databroker import Broker
+from tiled.client.container import Container
 
-from .data_access import DataAccess, TiledDataAccess, DatabrokerDataAccess
+from .data_access import DataAccess, DatabrokerDataAccess, TiledDataAccess
 from .objectives import Objective
 from .protocols import EvaluationFunction
 
@@ -51,9 +51,13 @@ def default_evaluation_function(
         if id == "baseline":
             outcome.update({objective.name: (data[objective.name][0], None) for objective in objectives})
         elif isinstance(id, int):
-            outcome.update({objective.name: (data[objective.name][id % len(data[objective.name])], None) for objective in objectives})
+            outcome.update(
+                {objective.name: (data[objective.name][id % len(data[objective.name])], None) for objective in objectives}
+            )
         else:
-            raise ValueError(f"Invalid '_id' type for this evaluation function. Got: {type(id)} for suggestion: {suggestion}.")
+            raise ValueError(
+                f"Invalid '_id' type for this evaluation function. Got: {type(id)} for suggestion: {suggestion}."
+            )
         outcome["_id"] = id
         outcomes.append(outcome)
 
@@ -64,7 +68,7 @@ class DataAccessEvaluationFunction(EvaluationFunction):
     def __init__(self, data_access: DataAccess, objectives: list[Objective]):
         self.data_access = data_access
         self.objectives: list[Objective] = objectives
-    
+
     def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
         return default_evaluation_function(uid, suggestions, data_access=self.data_access, objectives=self.objectives)
 

--- a/src/blop/tests/unit/test_evaluation.py
+++ b/src/blop/tests/unit/test_evaluation.py
@@ -1,12 +1,17 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
-from tiled.client.container import Container
+import pytest
 from databroker import Broker
+from tiled.client.container import Container
 
-from blop.evaluation import default_evaluation_function, TiledEvaluationFunction, DatabrokerEvaluationFunction, DataAccessEvaluationFunction
+from blop.data_access import DataAccess, DatabrokerDataAccess, TiledDataAccess
+from blop.evaluation import (
+    DataAccessEvaluationFunction,
+    DatabrokerEvaluationFunction,
+    TiledEvaluationFunction,
+    default_evaluation_function,
+)
 from blop.objectives import Objective
-from blop.data_access import DataAccess, TiledDataAccess, DatabrokerDataAccess
 
 
 @pytest.fixture(scope="function")
@@ -37,6 +42,7 @@ def test_default_evaluation_function(mock_data_access):
             "_id": 1,
         },
     ]
+
 
 def test_default_evaluation_function_with_baseline(mock_data_access):
     suggestions = [
@@ -80,8 +86,10 @@ def test_default_evaluation_function_with_multiple_suggestions(mock_data_access)
         Objective(name="test_objective1", target="max"),
         Objective(name="test_objective2", target="max"),
     ]
-    
-    with patch.object(mock_data_access, "get_data", return_value={"test_objective1": [1.0, 3.0], "test_objective2": [2.0, 4.0]}):
+
+    with patch.object(
+        mock_data_access, "get_data", return_value={"test_objective1": [1.0, 3.0], "test_objective2": [2.0, 4.0]}
+    ):
         outcomes = default_evaluation_function(
             uid="123",
             suggestions=suggestions,
@@ -112,7 +120,9 @@ def test_default_evaluation_function_with_multiple_suggestions(mock_data_access)
             "x2": 1.1,
         },
     ]
-    with patch.object(mock_data_access, "get_data", return_value={"test_objective1": [1.1, 3.1], "test_objective2": [2.1, 4.1]}):
+    with patch.object(
+        mock_data_access, "get_data", return_value={"test_objective1": [1.1, 3.1], "test_objective2": [2.1, 4.1]}
+    ):
         outcomes = default_evaluation_function(
             uid="124",
             suggestions=suggestions,


### PR DESCRIPTION
# Evaluation functions

## Summary

Changing the name of "digestion" to "evaluation". Otherwise, the data flow would be
```
suggest -> acquire -> digest -> ingest
```
Digestion occurring before ingestion seems wrong...

It will soon be
```
suggest -> acquire -> evaluate -> ingest
```

## Main changes

This PR only adds evaluation functions & tests but does not use them in the main workflow. Digestion is still used but will be removed in a follow-up PR in favor of evaluation functions.

