### PR TITLE
Simplified DOF classes for Ax backend

### DIFF
--- a/src/blop/ax/dof.py
+++ b/src/blop/ax/dof.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal, cast
@@ -8,7 +9,7 @@ from bluesky.protocols import NamedMovable
 
 
 @dataclass(frozen=True, kw_only=True)
-class DOF:
+class DOF(ABC):
     name: str | None = None
     movable: NamedMovable | None = None
 
@@ -19,6 +20,9 @@ class DOF:
     @property
     def parameter_name(self) -> str:
         return self.name or cast(NamedMovable, self.movable).name
+
+    @abstractmethod
+    def to_ax_parameter_config(self) -> RangeParameterConfig | ChoiceParameterConfig: ...
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/blop/tests/unit/ax/test_dof.py
+++ b/src/blop/tests/unit/ax/test_dof.py
@@ -8,22 +8,33 @@ from ..conftest import MovableSignal
 
 def test_dof_movable():
     movable = MovableSignal(name="test_movable")
-    dof = DOF(movable=movable)
-    assert dof.parameter_name == "test_movable"
+    range_dof = RangeDOF(movable=movable, bounds=(0, 1), parameter_type="float", step_size=0.1, scaling="linear")
+    assert range_dof.parameter_name == "test_movable"
+    choice_dof = ChoiceDOF(
+        movable=movable, values=[0, 1, 2, 3, 4, 5], parameter_type="int", is_ordered=True, dependent_parameters=None
+    )
+    assert choice_dof.parameter_name == "test_movable"
 
 
 def test_dof_name():
-    dof = DOF(name="test_name")
-    assert dof.parameter_name == "test_name"
+    range_dof = RangeDOF(name="test_name", bounds=(0, 1), parameter_type="float", step_size=0.1, scaling="linear")
+    assert range_dof.parameter_name == "test_name"
+    choice_dof = ChoiceDOF(
+        name="test_name", values=[0, 1, 2, 3, 4, 5], parameter_type="int", is_ordered=True, dependent_parameters=None
+    )
+    assert choice_dof.parameter_name == "test_name"
 
 
 def test_dof_invalid():
     movable = MovableSignal(name="test_movable")
     with pytest.raises(ValueError):
-        DOF(movable=movable, name="test_movable")
+        RangeDOF(movable=movable, name="test_movable", bounds=(0, 1), parameter_type="float")
 
     with pytest.raises(ValueError):
-        DOF(movable=movable, name="test_name")
+        ChoiceDOF(movable=movable, name="test_name", values=[0, 1, 2, 3, 4, 5], parameter_type="int")
+
+    with pytest.raises(TypeError):
+        DOF(movable=movable, name="test_movable")  # type: ignore[arg-type]
 
 
 def test_range_dof():


### PR DESCRIPTION
Light wrapper around Ax parameters to allow for passing in `NamedMovable`s or names.

Work toward making the DOFs compliant with #194 