### PR TITLE
Deprecating bayesian.acquisition

### DIFF
--- a/src/blop/bayesian/acquisition/analytic.py
+++ b/src/blop/bayesian/acquisition/analytic.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from collections.abc import Callable
 
 import numpy as np
@@ -10,6 +11,13 @@ from botorch.acquisition.analytic import (  # type: ignore[import-untyped]
 )
 from botorch.models.model import Model  # type: ignore[import-untyped]
 from torch import Tensor
+
+warnings.warn(
+    "The analytic module is deprecated and will be removed in Blop v1.0.0. "
+    "Use botorch.acquisition.monte_carlo.SampleReducingMCAcquisitionFunction for constrained acquisition functions.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class ConstrainedUpperConfidenceBound(UpperConfidenceBound):

--- a/src/blop/bayesian/acquisition/monte_carlo.py
+++ b/src/blop/bayesian/acquisition/monte_carlo.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from collections.abc import Callable
 
 import numpy as np
@@ -14,6 +15,13 @@ from botorch.acquisition.multi_objective.monte_carlo import (  # type: ignore[im
 )
 from botorch.models.model import Model  # type: ignore[import-untyped]
 from torch import Tensor
+
+warnings.warn(
+    "The monte_carlo module is deprecated and will be removed in Blop v1.0.0. "
+    "Use botorch.acquisition.monte_carlo.SampleReducingMCAcquisitionFunction for constrained acquisition functions.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class qConstrainedUpperConfidenceBound(qUpperConfidenceBound):

--- a/src/blop/bayesian/models.py
+++ b/src/blop/bayesian/models.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 import botorch  # type: ignore[import-untyped]
@@ -16,6 +17,9 @@ def train_model(
     **kwargs: Any,
 ) -> None:
     """Fit all of the agent's models. All kwargs are passed to `botorch.fit.fit_gpytorch_mll`."""
+    warnings.warn(
+        "The train_model function is deprecated and will be removed in Blop v1.0.0.", DeprecationWarning, stacklevel=2
+    )
     fails = 0
     while True:
         try:
@@ -42,6 +46,11 @@ def construct_single_task_model(
     """
     Construct an untrained model for an objective.
     """
+    warnings.warn(
+        "The construct_single_task_model function is deprecated and will be removed in Blop v1.0.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     skew_dims = skew_dims if skew_dims is not None else [(i,) for i in range(X.shape[-1])]
 
@@ -80,6 +89,11 @@ def construct_multi_task_model(
     """
     Construct an untrained model for an objective.
     """
+    warnings.warn(
+        "The construct_multi_task_model function is deprecated and will be removed in Blop v1.0.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     num_inputs = X.shape[-1]
     num_tasks = Y.shape[-1]


### PR DESCRIPTION
 BoTorch has constrained acquisition functions already: https://github.com/meta-pytorch/botorch/blob/3ff4d243449d96295437b87368b8d76ea279286c/botorch/acquisition/monte_carlo.py#L146C7-L146C42