### PR TITLE
Temporarily pin fastapi to fix breaking change

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -12,12 +12,14 @@ python = ">=3.10.0,<3.14"
 
 [feature.dev.pypi-dependencies]
 blop = { path = ".", editable = true, extras = ["dev"] }
+fastapi = "<0.132.0"
 
 # CPU-only variant of dev feature
 [feature.dev-cpu.dependencies]
 
 [feature.dev-cpu.pypi-dependencies]
 blop = { path = ".", editable = true, extras = ["dev", "cpu"] }
+fastapi = "<0.132.0"
 
 [feature.dev-cpu.tasks]
 check = "pre-commit run --all-files"


### PR DESCRIPTION
Only relevant to building the docs since we use a Tiled server which depends on fastapi. Tiled team is aware of the issue.