### PR TITLE
Add `osx-arm64` to platforms list in `pixi.toml`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["jessica-moylan <jessicamoylan10@gmail.com>", "Thomas Hopkins <thopkins1@bnl.gov>"]
 channels = ["conda-forge"]
 name = "blop"
-platforms = ["linux-64"]
+platforms = ["linux-64", "osx-arm64"]
 version = "0.9.0"
 
 [dependencies]


### PR DESCRIPTION
Add `osx-arm64` to platforms list in `pixi.toml` to support Apple Silicon.