### PR TITLE
Scalarized objective use in Agent

### DIFF
--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -33,7 +33,7 @@ from ..protocols import (
 from ..queueserver import QueueserverClient, QueueserverOptimizationRunner
 from ..utils import InferredReadable
 from .dof import DOF, DOFConstraint
-from .objective import Objective, OutcomeConstraint, to_ax_objective_str
+from .objective import Objective, OutcomeConstraint, ScalarizedObjective, to_ax_objective_str
 from .optimizer import AxOptimizer
 
 logger = logging.getLogger(__name__)
@@ -236,7 +236,7 @@ class Agent(_AxAgentMixin):
         self,
         sensors: Sequence[Sensor],
         dofs: Sequence[DOF],
-        objectives: Sequence[Objective],
+        objectives: Sequence[Objective] | ScalarizedObjective,
         evaluation_function: EvaluationFunction,
         acquisition_plan: AcquisitionPlan | None = None,
         dof_constraints: Sequence[DOFConstraint] | None = None,

--- a/src/blop/ax/objective.py
+++ b/src/blop/ax/objective.py
@@ -38,6 +38,18 @@ class Objective:
     name: str
     minimize: bool
 
+    @property
+    def ax_expression(self) -> str:
+        """
+        Convert the objective to a string that can be used by Ax.
+
+        Returns
+        -------
+        str
+            The expression with the objective name, negated if minimizing.
+        """
+        return f"-{self.name}" if self.minimize else self.name
+
 
 class ScalarizedObjective:
     """
@@ -193,7 +205,7 @@ class OutcomeConstraint:
         return self.ax_constraint
 
 
-def to_ax_objective_str(objectives: Sequence[Objective]) -> str:
+def to_ax_objective_str(objectives: Sequence[Objective] | ScalarizedObjective) -> str:
     """
     Convert a list of objectives to a string that can be used by Ax.
 
@@ -202,14 +214,13 @@ def to_ax_objective_str(objectives: Sequence[Objective]) -> str:
 
     Parameters
     ----------
-    objectives : Sequence[Objective]
-        The objectives to convert to a string.
+    objectives : Sequence[Objective] | ScalarizedObjective
+        The objectives or single scalarized objective to convert to a string.
 
     Returns
     -------
     str
-        The string representation of the objectives, comma-separated with minus
-        signs for minimization.
+        The string representation of the objectives usable by Ax.
 
     Examples
     --------
@@ -220,5 +231,14 @@ def to_ax_objective_str(objectives: Sequence[Objective]) -> str:
     ... ]
     >>> to_ax_objective_str(objectives)
     'intensity, -width'
+
+    >>> from blop.ax.objective import ScalarizedObjective, to_ax_objective_str
+    >>> objective = ScalarizedObjective(expression="2 * x + 3 * y", minimize=False, x="obj1", y="obj2")
+    >>> to_ax_objective_str(objective)
+    2 * obj1 + 3 * obj2
     """
-    return ", ".join([o.name if not o.minimize else f"-{o.name}" for o in objectives])
+    return (
+        objectives.ax_expression
+        if isinstance(objectives, ScalarizedObjective)
+        else ", ".join([o.ax_expression for o in objectives])
+    )

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -258,18 +258,19 @@ def test_agent_init_actuator_string_raises(mock_evaluation_function):
 
 def test_agent_scalarized_objective(mock_evaluation_function):
     dof1 = RangeDOF(name="test1", bounds=(0, 10), parameter_type="float")
-    objective = ScalarizedObjective(
+    scalarized_objective = ScalarizedObjective(
         "-50 * x + 100 * y",
         minimize=False,
         x="obj1",
         y="obj2",
     )
 
+    # Validate that the call passes the arguments properly
     with patch("blop.ax.optimizer.Client.configure_optimization") as mock_configure_optimization:
         Agent(
             sensors=[],
             dofs=[dof1],
-            objectives=[objective],
+            objectives=scalarized_objective,
             evaluation_function=mock_evaluation_function,
         )
 
@@ -278,36 +279,13 @@ def test_agent_scalarized_objective(mock_evaluation_function):
             outcome_constraints=None,
         )
 
-
-def test_agent_scalarized_objective_multiple(mock_evaluation_function):
-    dof1 = RangeDOF(name="test1", bounds=(0, 10), parameter_type="float")
-    objectives = [
-        ScalarizedObjective(
-            "-50 * x + 100 * y",
-            minimize=True,
-            x="obj1",
-            y="obj2",
-        ),
-        ScalarizedObjective(
-            "250 * x + 3 * y",
-            minimize=True,
-            x="obj3",
-            y="obj4",
-        ),
-    ]
-
-    with patch("blop.ax.optimizer.Client.configure_optimization") as mock_configure_optimization:
-        Agent(
-            sensors=[],
-            dofs=[dof1],
-            objectives=objectives,
-            evaluation_function=mock_evaluation_function,
-        )
-
-        mock_configure_optimization.assert_called_once_with(
-            objective="-50 * x + 100 * y, 250 * x + 3 * y",
-            outcome_constraints=None,
-        )
+    # Validate that Ax can actually use this
+    Agent(
+        sensors=[],
+        dofs=[dof1],
+        objectives=scalarized_objective,
+        evaluation_function=mock_evaluation_function,
+    )
 
 
 def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -8,7 +8,7 @@ from bluesky_queueserver_api.zmq import REManagerAPI
 
 from blop.ax.agent import Agent, QueueserverAgent
 from blop.ax.dof import DOFConstraint, RangeDOF
-from blop.ax.objective import Objective
+from blop.ax.objective import Objective, ScalarizedObjective
 from blop.ax.optimizer import AxOptimizer
 from blop.callbacks.logger import OptimizationLogger
 from blop.protocols import AcquisitionPlan, EvaluationFunction
@@ -254,6 +254,60 @@ def test_agent_init_actuator_string_raises(mock_evaluation_function):
 
     with pytest.raises(ValueError, match="not strings"):
         Agent(sensors=[], dofs=[dof1, dof2], objectives=[objective], evaluation_function=mock_evaluation_function)
+
+
+def test_agent_scalarized_objective(mock_evaluation_function):
+    dof1 = RangeDOF(name="test1", bounds=(0, 10), parameter_type="float")
+    objective = ScalarizedObjective(
+        "-50 * x + 100 * y",
+        minimize=False,
+        x="obj1",
+        y="obj2",
+    )
+
+    with patch("blop.ax.optimizer.Client.configure_optimization") as mock_configure_optimization:
+        Agent(
+            sensors=[],
+            dofs=[dof1],
+            objectives=[objective],
+            evaluation_function=mock_evaluation_function,
+        )
+
+        mock_configure_optimization.assert_called_once_with(
+            objective="-50 * obj1 + 100 * obj2",
+            outcome_constraints=None,
+        )
+
+
+def test_agent_scalarized_objective_multiple(mock_evaluation_function):
+    dof1 = RangeDOF(name="test1", bounds=(0, 10), parameter_type="float")
+    objectives = [
+        ScalarizedObjective(
+            "-50 * x + 100 * y",
+            minimize=True,
+            x="obj1",
+            y="obj2",
+        ),
+        ScalarizedObjective(
+            "250 * x + 3 * y",
+            minimize=True,
+            x="obj3",
+            y="obj4",
+        ),
+    ]
+
+    with patch("blop.ax.optimizer.Client.configure_optimization") as mock_configure_optimization:
+        Agent(
+            sensors=[],
+            dofs=[dof1],
+            objectives=objectives,
+            evaluation_function=mock_evaluation_function,
+        )
+
+        mock_configure_optimization.assert_called_once_with(
+            objective="-50 * x + 100 * y, 250 * x + 3 * y",
+            outcome_constraints=None,
+        )
 
 
 def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):


### PR DESCRIPTION
Enables the use of scalarized objectives with Ax.

I tested with Ax and you can't have a multi-objective setup with one of them being a scalarized objective. You could always just do the scalarization in your evaluation function, if you really wanted to.

Closes #283 