### PR TITLE
Fix stop_listener and incorrect usage of UID in stop document comparison in queueserver

### DIFF
--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -603,6 +603,17 @@ class QueueserverAgent(_AxAgentMixin):
     def acquisition_plan(self) -> str | None:
         return self._acquisition_plan
 
+    @property
+    def is_running(self) -> bool:
+        return self._runner.is_running
+
+    @property
+    def current_iteration(self) -> int:
+        return self._runner.current_iteration
+
+    def stop(self) -> None:
+        self._runner.stop()
+
     def to_optimization_problem(self) -> QueueserverOptimizationProblem:
         return QueueserverOptimizationProblem(
             optimizer=self._optimizer,

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -53,7 +53,11 @@ class ConsumerCallback(CallbackBase):
 
     def stop(self, doc: RunStop) -> None:
         """Executes the callback if the cached start and stop document match"""
-        if self._callback is not None and self._start_doc_cache is not None and self._start_doc_cache["uid"] == doc["uid"]:
+        if (
+            self._callback is not None
+            and self._start_doc_cache is not None
+            and self._start_doc_cache["uid"] == doc["run_start"]
+        ):
             self._callback(self._start_doc_cache, doc)
         self._start_doc_cache = None
 
@@ -414,5 +418,4 @@ class QueueserverOptimizationRunner:
             self._submit_next()
         else:
             self._state.finished = True
-            self._client.stop_listener()
             logger.info(f"Optimization complete after {self._state.current_iteration} iterations")

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -303,6 +303,8 @@ def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):
     assert agent.actuators == [dof1.actuator, dof2.actuator]
     assert agent.evaluation_function == mock_evaluation_function
     assert agent.acquisition_plan is None
+    assert not agent.is_running
+    assert agent.current_iteration == 0
     assert isinstance(agent.ax_client, Client)
 
     problem = agent.to_optimization_problem()
@@ -371,6 +373,28 @@ def test_queueserver_agent_submit_suggestions(
     suggestions = [{"test_motor1": 5, "test_motor2": 9}]
     agent.submit_suggestions(suggestions)
     mock_queueserver_runner_cls.return_value.submit_suggestions.assert_called_once_with(suggestions)
+
+
+@patch("blop.ax.agent.QueueserverClient")
+@patch("blop.ax.agent.QueueserverOptimizationRunner")
+def test_queueserver_agent_stop(
+    mock_queueserver_runner_cls, mock_queueserver_client_cls, mock_re_manager_api, mock_evaluation_function
+):
+    dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
+    dof2 = RangeDOF(actuator="test_motor2", bounds=(0, 10), parameter_type="float")
+    agent = QueueserverAgent(
+        mock_re_manager_api,
+        "inproc://test",
+        ["det"],
+        [dof1, dof2],
+        [Objective(name="obj1", minimize=False)],
+        mock_evaluation_function,
+    )
+    mock_queueserver_client_cls.assert_called_once()
+    mock_queueserver_runner_cls.assert_called_once()
+
+    agent.stop()
+    mock_queueserver_runner_cls.return_value.stop.assert_called_once()
 
 
 @pytest.fixture()

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -29,8 +29,9 @@ def test_consumer_callback_caches_start_and_calls_on_stop():
     """Test ConsumerCallback caches start doc and calls callback on stop."""
     mock_callback = MagicMock()
     callback = ConsumerCallback(callback=mock_callback)
-    start_doc = {"uid": "test-uid", CORRELATION_UID_KEY: "123", "time": 123}
-    stop_doc = {"uid": "test-uid", "exit_status": "success"}
+    run_uid = "test-uid"
+    start_doc = {"uid": run_uid, CORRELATION_UID_KEY: "123", "time": 123}
+    stop_doc = {"uid": "test-uid2", "run_start": run_uid, "exit_status": "success"}
 
     callback.start(start_doc)
     mock_callback.assert_not_called()
@@ -43,8 +44,9 @@ def test_consumer_callback_clears_cache_after_stop():
     """Test ConsumerCallback clears cache after stop is called."""
     mock_callback = MagicMock()
     callback = ConsumerCallback(callback=mock_callback)
-    start_doc = {"uid": "test-uid", CORRELATION_UID_KEY: "123"}
-    stop_doc = {"uid": "test-uid"}
+    run_uid = "test-uid"
+    start_doc = {"uid": run_uid, CORRELATION_UID_KEY: "123"}
+    stop_doc = {"uid": "test-uid2", "run_start": run_uid}
 
     callback.start(start_doc)
     callback.stop(stop_doc)


### PR DESCRIPTION
Closes #290 
Closes #289 

Also, adds some missing properties and the `stop` method, both of which are useful to inspect the state of the runner. This is because `agent.run()` returns immediately and the optimization loop runs in a background thread.