### PR TITLE
Prevent parallel runs of the queueserver runner

### DIFF
--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -237,6 +237,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
         registered = []
         for suggestion in suggestions:
             # Extract parameters (ignore _id if present)
+            # TODO: Overwrite ID_KEY or skip (assume already registered)?
             parameters = {k: v for k, v in suggestion.items() if k != ID_KEY}
 
             # Attach trial to Ax experiment

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -279,8 +279,6 @@ class QueueserverOptimizationRunner:
         ValueError
             If required devices or plans are not available.
         """
-        if self.is_running:
-            raise RuntimeError("Optimization loop is already running.")
         self._validate()
         self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
         self._continuous = True
@@ -300,8 +298,6 @@ class QueueserverOptimizationRunner:
             - Optimizer suggestions (with "_id" keys from suggest())
             - Manual points (without "_id", requires CanRegisterSuggestions protocol)
         """
-        if self.is_running:
-            raise RuntimeError("Optimization loop is already running.")
         self._validate()
         self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
         self._continuous = False
@@ -322,6 +318,8 @@ class QueueserverOptimizationRunner:
 
     def _validate(self) -> None:
         """Validate queueserver environment, devices, and plan availability."""
+        if self.is_running:
+            raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
 
         # Collect device names from actuators and sensors

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -7,7 +7,6 @@ a queueserver, rather than directly through a RunEngine.
 
 import logging
 import threading
-import time
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -314,6 +314,20 @@ class QueueserverOptimizationRunner:
             self._validate()
             self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
             self._continuous = False
+
+        # Ensure all suggestions have an ID_KEY or register them with the optimizer
+        if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
+            ID_KEY not in suggestion for suggestion in suggestions
+        ):
+            raise ValueError(
+                f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes or your optimizer must "
+                "implement the `blop.protocols.CanRegisterSuggestions` protocol. Please review your optimizer "
+                f"implementation. Got suggestions: {suggestions}"
+            )
+        elif isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions):
+            suggestions = self.optimization_problem.optimizer.register_suggestions(suggestions)
+
+        with self._state_lock:
             plan = self._build_plan(suggestions)
             logger.info(f"Submitting manually specified suggestion(s) with correlation uid: {self._state.current_uid}")
         self._client.start_listener(on_stop=self._on_acquisition_complete)
@@ -344,23 +358,9 @@ class QueueserverOptimizationRunner:
         self._client.check_plan_available(self._plan_name)
 
     def _build_plan(self, suggestions: list[dict]) -> BPlan:
-        """LOCKED: Register provided suggestions and build the plan to submit."""
+        """LOCKED: Build the plan to submit and update current state."""
         if self._state is None:
             raise RuntimeError("_build_plan() called before run() or submit_suggestions()")
-
-        # Ensure all suggestions have an ID_KEY or register them with the optimizer
-        if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
-            ID_KEY not in suggestion for suggestion in suggestions
-        ):
-            raise ValueError(
-                f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes or your optimizer must "
-                "implement the `blop.protocols.CanRegisterSuggestions` protocol. Please review your optimizer "
-                f"implementation. Got suggestions: {suggestions}"
-            )
-        elif isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and all(
-            ID_KEY not in suggestion for suggestion in suggestions
-        ):
-            suggestions = self.optimization_problem.optimizer.register_suggestions(suggestions)
 
         self._state.current_iteration += 1
         self._state.current_suggestions = suggestions

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -241,7 +241,7 @@ class QueueserverOptimizationRunner:
         self._state: _OptimizationState | None = None
         self._continuous = True
         self._autostart = True
-        self._state_lock = threading.Lock()
+        self._state_lock = threading.RLock()
 
     @property
     def optimization_problem(self) -> QueueserverOptimizationProblem:
@@ -262,11 +262,11 @@ class QueueserverOptimizationRunner:
 
     def run(self, iterations: int = 1, num_points: int = 1) -> None:
         """
-        Start the optimization loop.
+        Run the optimization loop.
 
         Validates the queueserver state, then begins the suggest -> acquire -> ingest
         cycle. This method returns immediately; the optimization runs asynchronously
-        via callbacks.
+        via callbacks on the Bluesky document stream.
 
         Parameters
         ----------
@@ -282,17 +282,25 @@ class QueueserverOptimizationRunner:
         ValueError
             If required devices or plans are not available.
         """
-        self._validate()
         with self._state_lock:
+            self._validate()
             self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
             self._continuous = True
+        suggestions = self._problem.optimizer.suggest(num_points)
+        with self._state_lock:
+            plan = self._build_plan(suggestions)
+            logger.info(
+                f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
+                f"with correlation uid: {self._state.current_uid}"
+            )
         self._client.start_listener(on_stop=self._on_acquisition_complete)
-        self._submit_next()
+        # TODO: Need to wait for connection handshake here
+        self._client.submit_plan(plan, autostart=self._autostart)
 
     def submit_suggestions(self, suggestions: list[dict]) -> None:
         """
         Manually submit suggestions to the queue. This method returns immediately; the
-        optimization runs asynchronously via callbacks.
+        optimization runs asynchronously via callbacks on the Bluesky document stream.
 
         Parameters
         ----------
@@ -302,18 +310,19 @@ class QueueserverOptimizationRunner:
             - Optimizer suggestions (with "_id" keys from suggest())
             - Manual points (without "_id", requires CanRegisterSuggestions protocol)
         """
-        self._validate()
         with self._state_lock:
+            self._validate()
             self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
             self._continuous = False
+            plan = self._build_plan(suggestions)
+            logger.info(f"Submitting manually specified suggestion(s) with correlation uid: {self._state.current_uid}")
         self._client.start_listener(on_stop=self._on_acquisition_complete)
-        self._submit_next_manual(suggestions)
+        # TODO: Need to wait for connection handshake here
+        self._client.submit_plan(plan, autostart=self._autostart)
 
     def stop(self) -> None:
         """
         Stop the optimization loop gracefully.
-
-        The current acquisition will complete, but no further iterations will run.
         """
         self._client.stop_listener()
         with self._state_lock:
@@ -323,7 +332,7 @@ class QueueserverOptimizationRunner:
         logger.info("Optimization stopped")
 
     def _validate(self) -> None:
-        """Validate queueserver environment, devices, and plan availability."""
+        """LOCKED: Validate not already running, queueserver environment, devices, and plan availability."""
         if self.is_running:
             raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
@@ -332,16 +341,14 @@ class QueueserverOptimizationRunner:
         actuator_names = list(self._problem.actuators)
         sensor_names = list(self._problem.sensors)
         self._client.check_devices_available(actuator_names + sensor_names)
-
         self._client.check_plan_available(self._plan_name)
 
-    def _submit_next_manual(self, suggestions: list[dict]) -> None:
-        """Get suggestions from optimizer and submit plan to queueserver."""
-        with self._state_lock:
-            if self._state is None:
-                raise RuntimeError("_submit_next called before run()")
+    def _build_plan(self, suggestions: list[dict]) -> BPlan:
+        """LOCKED: Register provided suggestions and build the plan to submit."""
+        if self._state is None:
+            raise RuntimeError("_build_plan() called before run() or submit_suggestions()")
 
-        # Ensure the suggestions have an ID_KEY or register them with the optimizer
+        # Ensure all suggestions have an ID_KEY or register them with the optimizer
         if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
             ID_KEY not in suggestion for suggestion in suggestions
         ):
@@ -350,41 +357,15 @@ class QueueserverOptimizationRunner:
                 "implement the `blop.protocols.CanRegisterSuggestions` protocol. Please review your optimizer "
                 f"implementation. Got suggestions: {suggestions}"
             )
-        elif isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions):
+        elif isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and all(
+            ID_KEY not in suggestion for suggestion in suggestions
+        ):
             suggestions = self.optimization_problem.optimizer.register_suggestions(suggestions)
 
-        with self._state_lock:
-            self._state.current_iteration += 1
-            self._state.current_suggestions = suggestions
-            self._state.current_uid = str(uuid.uuid4())
+        self._state.current_iteration += 1
+        self._state.current_suggestions = suggestions
+        self._state.current_uid = str(uuid.uuid4())
 
-        logger.info(f"Submitting manually specified suggestion(s) with correlation uid: {self._state.current_uid}")
-
-        plan = self._build_plan()
-        self._client.submit_plan(plan, autostart=self._autostart)
-
-    def _submit_next(self) -> None:
-        """Get suggestions from optimizer and submit plan to queueserver."""
-        with self._state_lock:
-            if self._state is None:
-                raise RuntimeError("_submit_next called before run()")
-            self._state.current_iteration += 1
-            self._state.current_suggestions = self._problem.optimizer.suggest(self._state.num_points)
-            self._state.current_uid = str(uuid.uuid4())
-
-            logger.info(
-                f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
-                f"with correlation uid: {self._state.current_uid}"
-            )
-
-        plan = self._build_plan()
-        self._client.submit_plan(plan, autostart=self._autostart)
-
-    def _build_plan(self) -> BPlan:
-        """Construct a BPlan from the current suggestions."""
-        with self._state_lock:
-            if self._state is None:
-                raise RuntimeError("_build_plan called before run()")
         # Build metadata
         md: dict[str, Any] = {
             CORRELATION_UID_KEY: self._state.current_uid,
@@ -412,23 +393,33 @@ class QueueserverOptimizationRunner:
                     f"Got: {start_doc.get('blop_correlation_uid', None)}, Expected: {self._state.current_uid}"
                 )
             logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
+            suggestions = self._state.current_suggestions
 
-            # Evaluate the results
-            outcomes = self._problem.evaluation_function(
-                uid=start_doc["uid"],
-                suggestions=self._state.current_suggestions,
-            )
-
+        # Evaluate the results
+        outcomes = self._problem.evaluation_function(uid=start_doc["uid"], suggestions=suggestions)
         logger.info(f"Evaluated {len(outcomes)} outcomes")
 
         # Ingest into optimizer
         self._problem.optimizer.ingest(outcomes)
 
-        # Continue if appropriate
+        # Check if done
         with self._state_lock:
-            if self._continuous and self._state.current_iteration < self._state.max_iterations:
-                logger.info("Continuing to next iteration")
-                self._submit_next()
-            else:
-                self._state.finished = True
+            if not self._continuous or self._state.current_iteration >= self._state.max_iterations:
                 logger.info(f"Optimization complete after {self._state.current_iteration} iterations")
+                self._state.finished = True
+                should_continue = False
+            else:
+                should_continue = True
+
+        # Continue if appropriate
+        if should_continue:
+            with self._state_lock:
+                num_points = self._state.num_points
+            suggestions = self._problem.optimizer.suggest(num_points)
+            with self._state_lock:
+                plan = self._build_plan(suggestions)
+                logger.info(
+                    f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
+                    f"with correlation uid: {self._state.current_uid}"
+                )
+            self._client.submit_plan(plan, autostart=self._autostart)

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -7,6 +7,7 @@ a queueserver, rather than directly through a RunEngine.
 
 import logging
 import threading
+import time
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -279,7 +280,8 @@ class QueueserverOptimizationRunner:
         ValueError
             If required devices or plans are not available.
         """
-        # TODO: What if there is already a run in-progress?
+        if self.is_running:
+            raise RuntimeError("Optimization loop is already running.")
         self._validate()
         self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
         self._continuous = True
@@ -299,6 +301,8 @@ class QueueserverOptimizationRunner:
             - Optimizer suggestions (with "_id" keys from suggest())
             - Manual points (without "_id", requires CanRegisterSuggestions protocol)
         """
+        if self.is_running:
+            raise RuntimeError("Optimization loop is already running.")
         self._validate()
         self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
         self._continuous = False

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -241,6 +241,7 @@ class QueueserverOptimizationRunner:
         self._state: _OptimizationState | None = None
         self._continuous = True
         self._autostart = True
+        self._state_lock = threading.Lock()
 
     @property
     def optimization_problem(self) -> QueueserverOptimizationProblem:
@@ -250,12 +251,14 @@ class QueueserverOptimizationRunner:
     @property
     def is_running(self) -> bool:
         """Whether an optimization run is currently in progress."""
-        return self._state is not None and not self._state.finished
+        with self._state_lock:
+            return self._state is not None and not self._state.finished
 
     @property
     def current_iteration(self) -> int:
         """The current iteration number (0 if not running)."""
-        return self._state.current_iteration if self._state else 0
+        with self._state_lock:
+            return self._state.current_iteration if self._state else 0
 
     def run(self, iterations: int = 1, num_points: int = 1) -> None:
         """
@@ -280,8 +283,9 @@ class QueueserverOptimizationRunner:
             If required devices or plans are not available.
         """
         self._validate()
-        self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
-        self._continuous = True
+        with self._state_lock:
+            self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
+            self._continuous = True
         self._client.start_listener(on_stop=self._on_acquisition_complete)
         self._submit_next()
 
@@ -299,8 +303,9 @@ class QueueserverOptimizationRunner:
             - Manual points (without "_id", requires CanRegisterSuggestions protocol)
         """
         self._validate()
-        self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
-        self._continuous = False
+        with self._state_lock:
+            self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
+            self._continuous = False
         self._client.start_listener(on_stop=self._on_acquisition_complete)
         self._submit_next_manual(suggestions)
 
@@ -310,10 +315,11 @@ class QueueserverOptimizationRunner:
 
         The current acquisition will complete, but no further iterations will run.
         """
-        self._continuous = False
         self._client.stop_listener()
-        if self._state is not None:
-            self._state.finished = True
+        with self._state_lock:
+            self._continuous = False
+            if self._state is not None:
+                self._state.finished = True
         logger.info("Optimization stopped")
 
     def _validate(self) -> None:
@@ -331,8 +337,9 @@ class QueueserverOptimizationRunner:
 
     def _submit_next_manual(self, suggestions: list[dict]) -> None:
         """Get suggestions from optimizer and submit plan to queueserver."""
-        if self._state is None:
-            raise RuntimeError("_submit_next called before run()")
+        with self._state_lock:
+            if self._state is None:
+                raise RuntimeError("_submit_next called before run()")
 
         # Ensure the suggestions have an ID_KEY or register them with the optimizer
         if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
@@ -346,9 +353,10 @@ class QueueserverOptimizationRunner:
         elif isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions):
             suggestions = self.optimization_problem.optimizer.register_suggestions(suggestions)
 
-        self._state.current_iteration += 1
-        self._state.current_suggestions = suggestions
-        self._state.current_uid = str(uuid.uuid4())
+        with self._state_lock:
+            self._state.current_iteration += 1
+            self._state.current_suggestions = suggestions
+            self._state.current_uid = str(uuid.uuid4())
 
         logger.info(f"Submitting manually specified suggestion(s) with correlation uid: {self._state.current_uid}")
 
@@ -357,24 +365,26 @@ class QueueserverOptimizationRunner:
 
     def _submit_next(self) -> None:
         """Get suggestions from optimizer and submit plan to queueserver."""
-        if self._state is None:
-            raise RuntimeError("_submit_next called before run()")
-        self._state.current_iteration += 1
-        self._state.current_suggestions = self._problem.optimizer.suggest(self._state.num_points)
-        self._state.current_uid = str(uuid.uuid4())
+        with self._state_lock:
+            if self._state is None:
+                raise RuntimeError("_submit_next called before run()")
+            self._state.current_iteration += 1
+            self._state.current_suggestions = self._problem.optimizer.suggest(self._state.num_points)
+            self._state.current_uid = str(uuid.uuid4())
 
-        logger.info(
-            f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
-            f"with correlation uid: {self._state.current_uid}"
-        )
+            logger.info(
+                f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
+                f"with correlation uid: {self._state.current_uid}"
+            )
 
         plan = self._build_plan()
         self._client.submit_plan(plan, autostart=self._autostart)
 
     def _build_plan(self) -> BPlan:
         """Construct a BPlan from the current suggestions."""
-        if self._state is None:
-            raise RuntimeError("_build_plan called before run()")
+        with self._state_lock:
+            if self._state is None:
+                raise RuntimeError("_build_plan called before run()")
         # Build metadata
         md: dict[str, Any] = {
             CORRELATION_UID_KEY: self._state.current_uid,
@@ -391,22 +401,23 @@ class QueueserverOptimizationRunner:
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""
-        if self._state is None:
-            raise RuntimeError("_on_acquisition_complete called before run()")
-        if self._state.current_uid is None:
-            raise RuntimeError("current_uid not set")
-        if self._state.current_uid != start_doc.get("blop_correlation_uid", None):
-            raise RuntimeError(
-                "current_uid did not match start document. "
-                f"Got: {start_doc.get('blop_correlation_uid', None)}, Expected: {self._state.current_uid}"
-            )
-        logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
+        with self._state_lock:
+            if self._state is None:
+                raise RuntimeError("_on_acquisition_complete called before run()")
+            if self._state.current_uid is None:
+                raise RuntimeError("current_uid not set")
+            if self._state.current_uid != start_doc.get("blop_correlation_uid", None):
+                raise RuntimeError(
+                    "current_uid did not match start document. "
+                    f"Got: {start_doc.get('blop_correlation_uid', None)}, Expected: {self._state.current_uid}"
+                )
+            logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
 
-        # Evaluate the results
-        outcomes = self._problem.evaluation_function(
-            uid=start_doc["uid"],
-            suggestions=self._state.current_suggestions,
-        )
+            # Evaluate the results
+            outcomes = self._problem.evaluation_function(
+                uid=start_doc["uid"],
+                suggestions=self._state.current_suggestions,
+            )
 
         logger.info(f"Evaluated {len(outcomes)} outcomes")
 
@@ -414,9 +425,10 @@ class QueueserverOptimizationRunner:
         self._problem.optimizer.ingest(outcomes)
 
         # Continue if appropriate
-        if self._continuous and self._state.current_iteration < self._state.max_iterations:
-            logger.info("Continuing to next iteration")
-            self._submit_next()
-        else:
-            self._state.finished = True
-            logger.info(f"Optimization complete after {self._state.current_iteration} iterations")
+        with self._state_lock:
+            if self._continuous and self._state.current_iteration < self._state.max_iterations:
+                logger.info("Continuing to next iteration")
+                self._submit_next()
+            else:
+                self._state.finished = True
+                logger.info(f"Optimization complete after {self._state.current_iteration} iterations")

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -232,6 +233,41 @@ def test_runner_run_submits_suggestions_to_queueserver():
     assert submitted_plan.name == "my_acquire"
 
 
+def test_runner_run_twice_fails():
+    """Test 2 calls to run() fails."""
+    submit_event = threading.Event()
+
+    def set_event(*args, **kwargs):
+        submit_event.set()
+
+    mock_client = MagicMock(spec=QueueserverClient)
+    mock_client.submit_plan.side_effect = set_event
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(),
+        actuators=["motor1"],
+        sensors=["det"],
+        evaluation_function=MagicMock(),
+        acquisition_plan="my_acquire",
+    )
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+    assert runner.optimization_problem == mock_optimization_problem
+
+    runner.run(iterations=1, num_points=1)
+    submit_event.wait(timeout=5)
+    if not submit_event.is_set():
+        pytest.fail("Submit event timed out")
+
+    with pytest.raises(RuntimeError, match="already running"):
+        runner.run(iterations=1, num_points=1)
+
+    with pytest.raises(RuntimeError, match="already running"):
+        suggestions = [{"motor1": 5}]
+        runner.submit_suggestions(suggestions)
+
+
 def test_runner_stop_sets_finished_state(mock_optimization_problem):
     """Test stop() marks the runner as finished and stops listener."""
     mock_client = MagicMock(spec=QueueserverClient)
@@ -279,6 +315,43 @@ def test_runner_submit_suggestions_to_queueserver():
     mock_client.submit_plan.assert_called_once()
     submitted_plan = mock_client.submit_plan.call_args[0][0]
     assert submitted_plan.name == "my_acquire"
+
+
+def test_runner_submit_suggestions_twice_fails():
+    """Test 2 calls to submit_suggestions() fails."""
+    submit_event = threading.Event()
+
+    def set_event(*args, **kwargs):
+        submit_event.set()
+
+    mock_client = MagicMock(spec=QueueserverClient)
+    mock_client.submit_plan.side_effect = set_event
+
+    class CustomOptimizer(Optimizer, CanRegisterSuggestions): ...
+
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(spec=CustomOptimizer),
+        actuators=["motor1"],
+        sensors=["det"],
+        evaluation_function=MagicMock(),
+        acquisition_plan="my_acquire",
+    )
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    suggestions = [{"motor1": 5}]
+    runner.submit_suggestions(suggestions)
+    submit_event.wait(timeout=5)
+    if not submit_event.is_set():
+        pytest.fail("Submit event timed out")
+
+    with pytest.raises(RuntimeError, match="already running"):
+        runner.submit_suggestions(suggestions)
+
+    with pytest.raises(RuntimeError, match="already running"):
+        runner.run(iterations=1)
 
 
 def test_runner_run_full_cycle(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -381,11 +381,11 @@ def test_runner_run_full_cycle(mock_optimization_problem):
     runner.run(iterations=3, num_points=2)
 
     # Simulate 3 acquisition completions by invoking the captured callback
-    for _ in range(3):
+    for i in range(3):
         current_uid = runner._state.current_uid
-        uid = f"fake-uid-{_}"
+        uid = f"fake-uid-{i}"
         start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
-        stop_doc = {"uid": uid}
+        stop_doc = {"uid": "other-fake-uid", "run_start": uid}
         mock_client._on_stop(start_doc, stop_doc)
 
     assert mock_client.submit_plan.call_count == 3
@@ -413,7 +413,7 @@ def test_runner_on_acquisition_complete_raises_on_uid_mismatch(mock_optimization
 
     # Callback with wrong blop_correlation_uid should raise
     start_doc = {"uid": "fake-uid", CORRELATION_UID_KEY: "wrong-uid"}
-    stop_doc = {"uid": "fake-uid"}
+    stop_doc = {"uid": "other-fake-uid", "run_start": "fake-uid"}
 
     with pytest.raises(RuntimeError, match="current_uid did not match start document"):
         mock_client._on_stop(start_doc, stop_doc)

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -317,6 +317,30 @@ def test_runner_submit_suggestions_to_queueserver():
     assert submitted_plan.name == "my_acquire"
 
 
+def test_runner_submit_suggestions_register_fails():
+    """Test run() gets suggestions from optimizer and submits plan to queueserver."""
+    mock_client = MagicMock(spec=QueueserverClient)
+
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(spec=Optimizer),
+        actuators=["motor1"],
+        sensors=["det"],
+        evaluation_function=MagicMock(),
+        acquisition_plan="my_acquire",
+    )
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    suggestions = [{"motor1": 5}]
+    with pytest.raises(ValueError, match="'_id'"):
+        runner.submit_suggestions(suggestions)
+
+    # Verify optimizer.suggest was NOT called
+    mock_optimization_problem.optimizer.suggest.assert_not_called()
+
+
 def test_runner_submit_suggestions_twice_fails():
     """Test 2 calls to submit_suggestions() fails."""
     submit_event = threading.Event()
@@ -417,3 +441,17 @@ def test_runner_on_acquisition_complete_raises_on_uid_mismatch(mock_optimization
 
     with pytest.raises(RuntimeError, match="current_uid did not match start document"):
         mock_client._on_stop(start_doc, stop_doc)
+
+
+def test_runner_private_method_calls_before_run(mock_optimization_problem):
+    mock_client = MagicMock(spec=QueueserverClient)
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    with pytest.raises(RuntimeError, match="run()"):
+        runner._build_plan([{}])
+
+    with pytest.raises(RuntimeError, match="run()"):
+        runner._on_acquisition_complete({}, {})


### PR DESCRIPTION
Two threads would be modifying the same optimization state, which we can't allow.

Locking is necessary to synchronize read/write of the optimization state between the main thread and the ZMQ dispatcher thread's callback.