### PR TITLE
Fix stream filtering on logging callback

### DIFF
--- a/src/blop/callbacks/router.py
+++ b/src/blop/callbacks/router.py
@@ -2,6 +2,7 @@ from bluesky.callbacks import CallbackBase
 from event_model import RunRouter
 
 from ..plans import OPTIMIZE_RUN_KEY, SAMPLE_SUGGESTIONS_RUN_KEY
+from .utils import _PrimaryStreamFilter
 
 
 class OptimizationCallbackRouter:
@@ -27,7 +28,7 @@ class OptimizationCallbackRouter:
 
     def _factory(self, name, doc):
         if name == "start" and doc.get("run_key") in (OPTIMIZE_RUN_KEY, SAMPLE_SUGGESTIONS_RUN_KEY):
-            return list(self._callbacks), []
+            return [_PrimaryStreamFilter(cb) for cb in self._callbacks], []
         return [], []
 
     def __call__(self, name, doc):

--- a/src/blop/callbacks/utils.py
+++ b/src/blop/callbacks/utils.py
@@ -50,8 +50,8 @@ class _PrimaryStreamFilter(CallbackBase):
     Descriptor documents whose stream name (``doc["name"]``) is not
     ``"primary"`` are silently dropped. Event documents are forwarded only
     when their corresponding descriptor was accepted. All other document
-    types (``start``, ``stop``, ``resource``, ``datum``, etc.) are passed
-    through unconditionally, as they are run-level rather than stream-level.
+    types (``start``, ``stop``) are passed through unconditionally, as 
+    they are run-level rather than stream-level.
 
     Parameters
     ----------

--- a/src/blop/callbacks/utils.py
+++ b/src/blop/callbacks/utils.py
@@ -1,5 +1,8 @@
 import math
 
+from bluesky.callbacks import CallbackBase
+from event_model import Event, EventDescriptor, RunStart, RunStop
+
 
 class RunningStats:
     """Accumulates running statistics using Welford's online algorithm.
@@ -39,3 +42,41 @@ class RunningStats:
         if self.count < 2:
             return math.nan
         return math.sqrt(self._m2 / (self.count - 1))
+
+
+class _PrimaryStreamFilter(CallbackBase):
+    """Forwards only ``'primary'`` stream documents to a wrapped callback.
+
+    Descriptor documents whose stream name (``doc["name"]``) is not
+    ``"primary"`` are silently dropped. Event documents are forwarded only
+    when their corresponding descriptor was accepted. All other document
+    types (``start``, ``stop``, ``resource``, ``datum``, etc.) are passed
+    through unconditionally, as they are run-level rather than stream-level.
+
+    Parameters
+    ----------
+    callback : CallbackBase
+        The wrapped callback to receive filtered documents.
+    """
+
+    def __init__(self, callback: CallbackBase) -> None:
+        super().__init__()
+        self._callback = callback
+        self._primary_descriptor_uids: set[str] = set()
+
+    def start(self, doc: RunStart) -> RunStart | None:
+        return self._callback.start(doc)
+
+    def descriptor(self, doc: EventDescriptor) -> EventDescriptor | None:
+        if doc.get("name") == "primary":
+            self._primary_descriptor_uids.add(doc["uid"])
+            return self._callback.descriptor(doc)
+
+    def event(self, doc: Event) -> Event:
+        if doc.get("descriptor") in self._primary_descriptor_uids:
+            return self._callback.event(doc)
+        # TODO: Fix typing of `CallbackBase.event` in event-model
+        return None  # type: ignore
+
+    def stop(self, doc: RunStop) -> RunStop | None:
+        return self._callback.stop(doc)

--- a/src/blop/callbacks/utils.py
+++ b/src/blop/callbacks/utils.py
@@ -50,7 +50,7 @@ class _PrimaryStreamFilter(CallbackBase):
     Descriptor documents whose stream name (``doc["name"]``) is not
     ``"primary"`` are silently dropped. Event documents are forwarded only
     when their corresponding descriptor was accepted. All other document
-    types (``start``, ``stop``) are passed through unconditionally, as 
+    types (``start``, ``stop``) are passed through unconditionally, as
     they are run-level rather than stream-level.
 
     Parameters

--- a/src/blop/tests/callbacks/test_router.py
+++ b/src/blop/tests/callbacks/test_router.py
@@ -1,10 +1,15 @@
 from unittest.mock import MagicMock
 
 import pytest
+from bluesky import SupplementalData
 from bluesky.callbacks import CallbackBase
+from bluesky.run_engine import RunEngine
 
 from blop.callbacks.router import OptimizationCallbackRouter
-from blop.plans import OPTIMIZE_RUN_KEY, SAMPLE_SUGGESTIONS_RUN_KEY
+from blop.plans import OPTIMIZE_RUN_KEY, SAMPLE_SUGGESTIONS_RUN_KEY, optimize
+from blop.protocols import EvaluationFunction, OptimizationProblem, Optimizer
+
+from ..conftest import MovableSignal, ReadableSignal
 
 
 class _SpyCallback(CallbackBase):
@@ -68,3 +73,63 @@ def test_empty_callback_list():
 
     # Should not raise
     router("start", {"uid": "test123", "run_key": OPTIMIZE_RUN_KEY})
+
+
+@pytest.fixture()
+def RE():
+    return RunEngine({})
+
+
+@pytest.fixture()
+def optimization_problem():
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[{"objective": 0.0, "_id": 0}])
+    return OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+    )
+
+
+def test_baseline_stream_is_filtered_out(RE, optimization_problem):
+    """Router must not forward baseline stream descriptors or events to callbacks.
+
+    SupplementalData injects a 'baseline' stream (read at run start/end) into
+    every run, mimicking real beamline usage. The router should shield callbacks
+    from those documents and pass through only the 'primary' stream.
+    """
+
+    class _SpyAllCallback(CallbackBase):
+        def __init__(self):
+            super().__init__()
+            self.received: list[tuple[str, dict]] = []
+
+        def descriptor(self, doc):
+            self.received.append(("descriptor", doc))
+
+        def event(self, doc):
+            self.received.append(("event", doc))
+
+        def stop(self, doc):
+            self.received.append(("stop", doc))
+
+    baseline_device = ReadableSignal("temperature")
+    sd = SupplementalData(baseline=[baseline_device])
+    RE.preprocessors.append(sd)
+
+    cb = _SpyAllCallback()
+    router = OptimizationCallbackRouter([cb])
+    RE.subscribe(router)
+
+    RE(optimize(optimization_problem))
+
+    descriptor_stream_names = [doc["name"] for name, doc in cb.received if name == "descriptor"]
+    primary_descriptor_uids = {doc["uid"] for name, doc in cb.received if name == "descriptor"}
+    event_descriptor_uids = [doc["descriptor"] for name, doc in cb.received if name == "event"]
+    stop_docs = [doc for name, doc in cb.received if name == "stop"]
+
+    assert descriptor_stream_names == ["primary"], "only the primary descriptor should reach the callback"
+    assert all(uid in primary_descriptor_uids for uid in event_descriptor_uids), "baseline events must be filtered"
+    assert len(stop_docs) == 1, "stop must always pass through"


### PR DESCRIPTION
Closes #298 

# Summary

Adds a filter for `"primary"` stream to the callback, so that other streams like `"baseline"` are not included. `"primary"` is the only one needed since these callbacks are only intended to be used by Blop plans (which only have `"primary"` and nothing else). However, other streams, such as `"baseline"`, could be injected into Blop plans using Bluesky preprocessors, so we must be sure to filter them out.

## Motivation

Baseline has its own set of documents that were getting picked up by the logging callback unintentionally.

## Detailed changes

- Added a private `_PrimaryStreamFilter` callback that wraps other callbacks to filter out events that don't belong to the `"primary"` stream. This is the same filtering approach done in `bluesky.callbacks.LiveTable`.
- Added a test to be sure that when `"baseline"` is used, it gets filtered out properly
- Every callback that goes through the `OptimizationCallbackRouter` will have this filtering applied

Small note: the return type of `CallbackBase.event` is incorrect and should allow for `None`. I had to ignore for now until this is fixed upstream.