### PR TITLE
Use futures for better tracking of queueserver runner state

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -11,3 +11,4 @@ API Reference
     reference/outcome-constraint.rst
     reference/plans.rst
     reference/protocols.rst
+    reference/queueserver.rst

--- a/docs/source/reference/queueserver.rst
+++ b/docs/source/reference/queueserver.rst
@@ -1,0 +1,29 @@
+Queueserver
+===========
+
+These classes implement the distributed optimization backend that connects
+Blop to a remote `Bluesky Queueserver <https://blueskyproject.io/bluesky-queueserver/>`_.
+See the :doc:`/tutorials/queueserver` tutorial for a full worked example.
+
+OptimizationResult
+------------------
+
+.. autoclass:: blop.queueserver.OptimizationResult
+   :members:
+   :undoc-members:
+
+QueueserverClient
+-----------------
+
+.. autoclass:: blop.queueserver.QueueserverClient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+QueueserverOptimizationRunner
+------------------------------
+
+.. autoclass:: blop.queueserver.QueueserverOptimizationRunner
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -301,10 +301,10 @@ result = future.result()
 
 print(f"Iterations completed : {result.iterations_completed}")
 print(f"Points per iteration : {result.num_points}")
-print(f"Total acquisitions   : {len(result.run_uids)}")
+print(f"Total acquisitions   : {len(result.uids)}")
 print()
 print("Run UIDs:")
-for uid in result.run_uids:
+for uid in result.uids:
     print(f"  {uid}")
 ```
 

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -291,17 +291,21 @@ ZMQ proxy output port (5578) where Bluesky documents are published.
 The `run()` method is **non-blocking** — it submits the first plan and returns immediately. The agent reacts asynchronously to plan completions via ZMQ callbacks.
 
 ```{code-cell} ipython3
-agent.run(iterations=10, n_points=1)
+future = agent.run(iterations=10, n_points=1)
 ```
 
-Wait for the optimization to complete:
+Wait for the optimization to complete and inspect the result:
 
 ```{code-cell} ipython3
-while agent.is_running:
-    print(f"  Iteration {agent.current_iteration} in progress...")
-    time.sleep(5)
+result = future.result()
 
-print(f"Optimization complete after {agent.current_iteration} iterations")
+print(f"Iterations completed : {result.iterations_completed}")
+print(f"Points per iteration : {result.num_points}")
+print(f"Total acquisitions   : {len(result.run_uids)}")
+print()
+print("Run UIDs:")
+for uid in result.run_uids:
+    print(f"  {uid}")
 ```
 
 ## Viewing Results

--- a/src/blop/ax/__init__.py
+++ b/src/blop/ax/__init__.py
@@ -1,3 +1,4 @@
+from ..queueserver import OptimizationResult
 from .agent import Agent as Agent
 from .agent import QueueserverAgent as QueueserverAgent
 from .dof import DOF, ChoiceDOF, DOFConstraint, RangeDOF
@@ -16,4 +17,5 @@ __all__ = [
     "ScalarizedObjective",
     "to_ax_objective_str",
     "AxOptimizer",
+    "OptimizationResult",
 ]

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -1,6 +1,7 @@
 import importlib.util
 import logging
 from collections.abc import Mapping, Sequence
+from concurrent.futures import Future
 from typing import Any, cast
 
 from ax import Client, TOutcome, TParameterization
@@ -31,7 +32,7 @@ from ..protocols import (
     QueueserverOptimizationProblem,
     Sensor,
 )
-from ..queueserver import QueueserverClient, QueueserverOptimizationRunner
+from ..queueserver import OptimizationResult, QueueserverClient, QueueserverOptimizationRunner
 from ..utils import InferredReadable
 from .dof import DOF, DOFConstraint
 from .objective import Objective, OutcomeConstraint, ScalarizedObjective, to_ax_objective_str
@@ -659,16 +660,12 @@ class QueueserverAgent(_AxAgentMixin):
     def acquisition_plan(self) -> str | None:
         return self._acquisition_plan
 
-    @property
-    def is_running(self) -> bool:
-        return self._runner.is_running
+    def stop(self) -> None:
+        self._runner.stop()
 
     @property
     def current_iteration(self) -> int:
         return self._runner.current_iteration
-
-    def stop(self) -> None:
-        self._runner.stop()
 
     def to_optimization_problem(self) -> QueueserverOptimizationProblem:
         return QueueserverOptimizationProblem(
@@ -679,7 +676,7 @@ class QueueserverAgent(_AxAgentMixin):
             acquisition_plan=self._acquisition_plan,
         )
 
-    def run(self, iterations=1, n_points=1) -> None:
+    def run(self, iterations: int = 1, n_points: int = 1) -> Future[OptimizationResult]:
         """
         Start the optimization loop.
 
@@ -691,8 +688,16 @@ class QueueserverAgent(_AxAgentMixin):
         ----------
         iterations : int
             Number of optimization iterations to run.
-        num_points : int
+        n_points : int
             Number of points to suggest per iteration.
+
+        Returns
+        -------
+        concurrent.futures.Future[OptimizationResult]
+            A future that resolves to an :class:`~blop.queueserver.OptimizationResult`
+            when all iterations complete or when :meth:`stop` is called. If an
+            unhandled exception occurs the future will hold it and re-raise on
+            ``.result()``.
 
         Raises
         ------
@@ -701,10 +706,9 @@ class QueueserverAgent(_AxAgentMixin):
         ValueError
             If required devices or plans are not available.
         """
+        return self._runner.run(iterations, n_points)
 
-        self._runner.run(iterations, n_points)
-
-    def submit_suggestions(self, suggestions: list[dict]) -> None:
+    def submit_suggestions(self, suggestions: list[dict]) -> Future[OptimizationResult]:
         """
         Evaluate specific parameter combinations.
 
@@ -716,8 +720,14 @@ class QueueserverAgent(_AxAgentMixin):
         suggestions : list[dict]
             Either optimizer suggestions (with "_id") or manual points (without "_id").
 
+        Returns
+        -------
+        concurrent.futures.Future[OptimizationResult]
+            A future that resolves to an :class:`~blop.queueserver.OptimizationResult`
+            when the acquisition completes.
+
         See Also
         --------
-        suggest : Get optimizer suggestions.
+        run : Run the full optimization loop.
         """
-        self._runner.submit_suggestions(suggestions)
+        return self._runner.submit_suggestions(suggestions)

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -233,7 +233,6 @@ class _OptimizationState:
     current_iteration: int = 0
     current_suggestions: list[dict] = field(default_factory=list)
     current_uid: str | None = None
-    finished: bool = False
     run_uids: list[str] = field(default_factory=list)
 
     def build_result(self) -> OptimizationResult:
@@ -326,6 +325,7 @@ class QueueserverOptimizationRunner:
             future: Future[OptimizationResult] = Future()
             self._current_future = future
         suggestions = self._problem.optimizer.suggest(num_points)
+        # TODO: Need to wait for connection handshake here
         with self._state_lock:
             plan = self._build_plan(suggestions)
             logger.info(
@@ -333,7 +333,6 @@ class QueueserverOptimizationRunner:
                 f"with correlation uid: {self._state.current_uid}"
             )
         self._client.start_listener(on_stop=self._on_acquisition_complete)
-        # TODO: Need to wait for connection handshake here
         self._client.submit_plan(plan, autostart=self._autostart)
         return future
 
@@ -395,18 +394,35 @@ class QueueserverOptimizationRunner:
         self._client.stop_listener()
         with self._state_lock:
             self._continuous = False
-            if self._state is not None:
-                self._state.finished = True
-                result = self._state.build_result()
-            else:
-                result = OptimizationResult(iterations_completed=0, num_points=0, run_uids=())
-            if self._current_future is not None and not self._current_future.done():
-                self._current_future.set_result(result)
+            result = (
+                self._state.build_result()
+                if self._state is not None
+                else OptimizationResult(iterations_completed=0, num_points=0, run_uids=())
+            )
+            self._resolve_future(result)
         logger.info("Optimization stopped")
+
+    def _resolve_future(self, result: OptimizationResult) -> None:
+        """LOCKED: Resolve the current future with a result if it is not already done."""
+        if self._current_future is not None and not self._current_future.done():
+            self._current_future.set_result(result)
+
+    def _fail_future(self, exc: Exception) -> None:
+        """LOCKED: Resolve the current future with an exception if it is not already done."""
+        if self._current_future is not None and not self._current_future.done():
+            self._current_future.set_exception(exc)
+
+    def _try_register_failures(self, suggestions: list[dict]) -> None:
+        """Notify a TrialFaultAware optimizer of failed suggestions, if supported."""
+        if suggestions and isinstance(self._problem.optimizer, TrialFaultAware):
+            try:
+                self._problem.optimizer.register_failures(suggestions)
+            except Exception:
+                logger.exception("Failed to register trial failures with the optimizer")
 
     def _validate(self) -> None:
         """LOCKED: Validate not already running, queueserver environment, devices, and plan availability."""
-        if self._state is not None and not self._state.finished:
+        if self._current_future is not None and not self._current_future.done():
             raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
 
@@ -449,18 +465,9 @@ class QueueserverOptimizationRunner:
                 "Optimization has been stopped. Inspect the future's exception for details."
             )
             with self._state_lock:
-                if self._state is not None:
-                    suggestions = self._state.current_suggestions
-                    self._state.finished = True
-                else:
-                    suggestions = []
-                if self._current_future is not None and not self._current_future.done():
-                    self._current_future.set_exception(exc)
-            if suggestions and isinstance(self._problem.optimizer, TrialFaultAware):
-                try:
-                    self._problem.optimizer.register_failures(suggestions)
-                except Exception:
-                    logger.exception("Failed to register trial failures with the optimizer")
+                suggestions = self._state.current_suggestions if self._state is not None else []
+                self._fail_future(exc)
+            self._try_register_failures(suggestions)
 
     def _process_acquisition(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Core acquisition-complete logic (called from _on_acquisition_complete)."""
@@ -469,11 +476,15 @@ class QueueserverOptimizationRunner:
                 raise RuntimeError("_on_acquisition_complete called before run()")
             if self._state.current_uid is None:
                 raise RuntimeError("current_uid not set")
-            if self._state.current_uid != start_doc.get("blop_correlation_uid", None):
+            if self._state.current_uid != start_doc.get(CORRELATION_UID_KEY):
                 raise RuntimeError(
                     "current_uid did not match start document. "
-                    f"Got: {start_doc.get('blop_correlation_uid', None)}, Expected: {self._state.current_uid}"
+                    f"Got: {start_doc.get(CORRELATION_UID_KEY)}, Expected: {self._state.current_uid}"
                 )
+            exit_status = stop_doc.get("exit_status")
+            if exit_status != "success":
+                reason = stop_doc.get("reason") or "(no reason given)"
+                raise RuntimeError(f"Acquisition run {start_doc['uid']!r} ended with status {exit_status!r}: {reason}")
             logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
             suggestions = self._state.current_suggestions
             self._state.run_uids.append(start_doc["uid"])
@@ -489,12 +500,8 @@ class QueueserverOptimizationRunner:
         with self._state_lock:
             if not self._continuous or self._state.current_iteration >= self._state.max_iterations:
                 logger.info(f"Optimization complete after {self._state.current_iteration} iterations")
-                self._state.finished = True
                 result = self._state.build_result()
-                if self._current_future is None:
-                    raise RuntimeError("_current_future is None at completion — this is a bug")
-                if not self._current_future.done():
-                    self._current_future.set_result(result)
+                self._resolve_future(result)
                 return
 
         # Continue: get next suggestions and submit

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -400,7 +400,6 @@ class QueueserverOptimizationRunner:
         be resolved with a partial :class:`OptimizationResult` containing however
         many iterations completed before the stop.
         """
-        self._client.stop_listener()
         with self._state_lock:
             self._continuous = False
             result = (

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -428,6 +428,7 @@ class QueueserverOptimizationRunner:
                 self._problem.optimizer.register_failures(suggestions)
             except Exception:
                 logger.exception("Failed to register trial failures with the optimizer")
+                raise
 
     def _validate(self) -> None:
         """LOCKED: Validate not already running, queueserver environment, devices, and plan availability."""

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -322,18 +322,23 @@ class QueueserverOptimizationRunner:
             self._validate()
             self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
             self._continuous = True
-            future: Future[OptimizationResult] = Future()
-            self._current_future = future
         suggestions = self._problem.optimizer.suggest(num_points)
-        # TODO: Need to wait for connection handshake here
         with self._state_lock:
             plan = self._build_plan(suggestions)
             logger.info(
                 f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
                 f"with correlation uid: {self._state.current_uid}"
             )
-        self._client.start_listener(on_stop=self._on_acquisition_complete)
-        self._client.submit_plan(plan, autostart=self._autostart)
+            future: Future[OptimizationResult] = Future()
+            self._current_future = future
+        try:
+            self._client.start_listener(on_stop=self._on_acquisition_complete)
+            # TODO: Need to wait for connection handshake here
+            self._client.submit_plan(plan, autostart=self._autostart)
+        except Exception as exc:
+            with self._state_lock:
+                self._fail_future(exc)
+            raise
         return future
 
     def submit_suggestions(self, suggestions: list[dict]) -> Future[OptimizationResult]:
@@ -360,9 +365,6 @@ class QueueserverOptimizationRunner:
             self._validate()
             self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
             self._continuous = False
-            future: Future[OptimizationResult] = Future()
-            self._current_future = future
-
         # Ensure all suggestions have an ID_KEY or register them with the optimizer
         if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
             ID_KEY not in suggestion for suggestion in suggestions
@@ -378,9 +380,16 @@ class QueueserverOptimizationRunner:
         with self._state_lock:
             plan = self._build_plan(suggestions)
             logger.info(f"Submitting manually specified suggestion(s) with correlation uid: {self._state.current_uid}")
-        self._client.start_listener(on_stop=self._on_acquisition_complete)
-        # TODO: Need to wait for connection handshake here
-        self._client.submit_plan(plan, autostart=self._autostart)
+            future: Future[OptimizationResult] = Future()
+            self._current_future = future
+        try:
+            self._client.start_listener(on_stop=self._on_acquisition_complete)
+            # TODO: Need to wait for connection handshake here
+            self._client.submit_plan(plan, autostart=self._autostart)
+        except Exception as exc:
+            with self._state_lock:
+                self._fail_future(exc)
+            raise
         return future
 
     def stop(self) -> None:

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -9,6 +9,7 @@ import logging
 import threading
 import uuid
 from collections.abc import Callable, Sequence
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -19,13 +20,37 @@ from bluesky_queueserver_api.zmq import REManagerAPI
 from event_model import RunStart, RunStop
 
 from .plans import default_acquire
-from .protocols import ID_KEY, CanRegisterSuggestions, QueueserverOptimizationProblem
+from .protocols import ID_KEY, CanRegisterSuggestions, QueueserverOptimizationProblem, TrialFaultAware
 
 logger = logging.getLogger("blop")
 
 
 DEFAULT_ACQUIRE_PLAN_NAME: str = default_acquire.__name__
 CORRELATION_UID_KEY: Literal["blop_correlation_uid"] = "blop_correlation_uid"
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    """
+    The result of a completed or stopped optimization run.
+
+    Parameters
+    ----------
+    iterations_completed : int
+        The number of suggest -> acquire -> ingest cycles that finished
+        successfully. For a run stopped early via :meth:`QueueserverOptimizationRunner.stop`,
+        this reflects however many iterations completed before the stop.
+    num_points : int
+        The number of points suggested per iteration.
+    run_uids : tuple[str, ...]
+        The Bluesky run UIDs for each completed acquisition, in order.
+        These can be used to retrieve raw data from a Tiled or databroker
+        catalog for post-hoc analysis.
+    """
+
+    iterations_completed: int
+    num_points: int
+    run_uids: tuple[str, ...]
 
 
 class ConsumerCallback(CallbackBase):
@@ -209,6 +234,15 @@ class _OptimizationState:
     current_suggestions: list[dict] = field(default_factory=list)
     current_uid: str | None = None
     finished: bool = False
+    run_uids: list[str] = field(default_factory=list)
+
+    def build_result(self) -> OptimizationResult:
+        """Build an :class:`OptimizationResult` from the current state."""
+        return OptimizationResult(
+            iterations_completed=len(self.run_uids),
+            num_points=self.num_points,
+            run_uids=tuple(self.run_uids),
+        )
 
 
 class QueueserverOptimizationRunner:
@@ -242,6 +276,7 @@ class QueueserverOptimizationRunner:
         self._continuous = True
         self._autostart = True
         self._state_lock = threading.RLock()
+        self._current_future: Future[OptimizationResult] | None = None
 
     @property
     def optimization_problem(self) -> QueueserverOptimizationProblem:
@@ -249,18 +284,12 @@ class QueueserverOptimizationRunner:
         return self._problem
 
     @property
-    def is_running(self) -> bool:
-        """Whether an optimization run is currently in progress."""
-        with self._state_lock:
-            return self._state is not None and not self._state.finished
-
-    @property
     def current_iteration(self) -> int:
         """The current iteration number (0 if not running)."""
         with self._state_lock:
             return self._state.current_iteration if self._state else 0
 
-    def run(self, iterations: int = 1, num_points: int = 1) -> None:
+    def run(self, iterations: int = 1, num_points: int = 1) -> Future[OptimizationResult]:
         """
         Run the optimization loop.
 
@@ -275,6 +304,14 @@ class QueueserverOptimizationRunner:
         num_points : int
             Number of points to suggest per iteration.
 
+        Returns
+        -------
+        concurrent.futures.Future[OptimizationResult]
+            A future that resolves to an :class:`OptimizationResult` when all
+            iterations complete, or when :meth:`stop` is called. If the
+            optimization loop raises an unhandled exception the future will
+            hold that exception and re-raise it on ``.result()``.
+
         Raises
         ------
         RuntimeError
@@ -286,6 +323,8 @@ class QueueserverOptimizationRunner:
             self._validate()
             self._state = _OptimizationState(max_iterations=iterations, num_points=num_points)
             self._continuous = True
+            future: Future[OptimizationResult] = Future()
+            self._current_future = future
         suggestions = self._problem.optimizer.suggest(num_points)
         with self._state_lock:
             plan = self._build_plan(suggestions)
@@ -296,8 +335,9 @@ class QueueserverOptimizationRunner:
         self._client.start_listener(on_stop=self._on_acquisition_complete)
         # TODO: Need to wait for connection handshake here
         self._client.submit_plan(plan, autostart=self._autostart)
+        return future
 
-    def submit_suggestions(self, suggestions: list[dict]) -> None:
+    def submit_suggestions(self, suggestions: list[dict]) -> Future[OptimizationResult]:
         """
         Manually submit suggestions to the queue. This method returns immediately; the
         optimization runs asynchronously via callbacks on the Bluesky document stream.
@@ -309,11 +349,20 @@ class QueueserverOptimizationRunner:
 
             - Optimizer suggestions (with "_id" keys from suggest())
             - Manual points (without "_id", requires CanRegisterSuggestions protocol)
+
+        Returns
+        -------
+        concurrent.futures.Future[OptimizationResult]
+            A future that resolves to an :class:`OptimizationResult` when the
+            acquisition completes. If an unhandled exception occurs the future
+            will hold it and re-raise on ``.result()``.
         """
         with self._state_lock:
             self._validate()
             self._state = _OptimizationState(max_iterations=1, num_points=len(suggestions))
             self._continuous = False
+            future: Future[OptimizationResult] = Future()
+            self._current_future = future
 
         # Ensure all suggestions have an ID_KEY or register them with the optimizer
         if not isinstance(self.optimization_problem.optimizer, CanRegisterSuggestions) and any(
@@ -333,21 +382,31 @@ class QueueserverOptimizationRunner:
         self._client.start_listener(on_stop=self._on_acquisition_complete)
         # TODO: Need to wait for connection handshake here
         self._client.submit_plan(plan, autostart=self._autostart)
+        return future
 
     def stop(self) -> None:
         """
         Stop the optimization loop gracefully.
+
+        The future returned by :meth:`run` or :meth:`submit_suggestions` will
+        be resolved with a partial :class:`OptimizationResult` containing however
+        many iterations completed before the stop.
         """
         self._client.stop_listener()
         with self._state_lock:
             self._continuous = False
             if self._state is not None:
                 self._state.finished = True
+                result = self._state.build_result()
+            else:
+                result = OptimizationResult(iterations_completed=0, num_points=0, run_uids=())
+            if self._current_future is not None and not self._current_future.done():
+                self._current_future.set_result(result)
         logger.info("Optimization stopped")
 
     def _validate(self) -> None:
         """LOCKED: Validate not already running, queueserver environment, devices, and plan availability."""
-        if self.is_running:
+        if self._state is not None and not self._state.finished:
             raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
 
@@ -382,6 +441,29 @@ class QueueserverOptimizationRunner:
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""
+        try:
+            self._process_acquisition(start_doc, stop_doc)
+        except Exception as exc:
+            logger.exception(
+                "Unhandled exception in optimization background thread. "
+                "Optimization has been stopped. Inspect the future's exception for details."
+            )
+            with self._state_lock:
+                if self._state is not None:
+                    suggestions = self._state.current_suggestions
+                    self._state.finished = True
+                else:
+                    suggestions = []
+                if self._current_future is not None and not self._current_future.done():
+                    self._current_future.set_exception(exc)
+            if suggestions and isinstance(self._problem.optimizer, TrialFaultAware):
+                try:
+                    self._problem.optimizer.register_failures(suggestions)
+                except Exception:
+                    logger.exception("Failed to register trial failures with the optimizer")
+
+    def _process_acquisition(self, start_doc: RunStart, stop_doc: RunStop) -> None:
+        """Core acquisition-complete logic (called from _on_acquisition_complete)."""
         with self._state_lock:
             if self._state is None:
                 raise RuntimeError("_on_acquisition_complete called before run()")
@@ -394,6 +476,7 @@ class QueueserverOptimizationRunner:
                 )
             logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
             suggestions = self._state.current_suggestions
+            self._state.run_uids.append(start_doc["uid"])
 
         # Evaluate the results
         outcomes = self._problem.evaluation_function(uid=start_doc["uid"], suggestions=suggestions)
@@ -407,19 +490,21 @@ class QueueserverOptimizationRunner:
             if not self._continuous or self._state.current_iteration >= self._state.max_iterations:
                 logger.info(f"Optimization complete after {self._state.current_iteration} iterations")
                 self._state.finished = True
-                should_continue = False
-            else:
-                should_continue = True
+                result = self._state.build_result()
+                if self._current_future is None:
+                    raise RuntimeError("_current_future is None at completion — this is a bug")
+                if not self._current_future.done():
+                    self._current_future.set_result(result)
+                return
 
-        # Continue if appropriate
-        if should_continue:
-            with self._state_lock:
-                num_points = self._state.num_points
-            suggestions = self._problem.optimizer.suggest(num_points)
-            with self._state_lock:
-                plan = self._build_plan(suggestions)
-                logger.info(
-                    f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
-                    f"with correlation uid: {self._state.current_uid}"
-                )
-            self._client.submit_plan(plan, autostart=self._autostart)
+        # Continue: get next suggestions and submit
+        with self._state_lock:
+            num_points = self._state.num_points
+        suggestions = self._problem.optimizer.suggest(num_points)
+        with self._state_lock:
+            plan = self._build_plan(suggestions)
+            logger.info(
+                f"Submitting iteration {self._state.current_iteration}/{self._state.max_iterations} "
+                f"with correlation uid: {self._state.current_uid}"
+            )
+        self._client.submit_plan(plan, autostart=self._autostart)

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -42,7 +42,7 @@ class OptimizationResult:
         this reflects however many iterations completed before the stop.
     num_points : int
         The number of points suggested per iteration.
-    run_uids : tuple[str, ...]
+    uids : tuple[str, ...]
         The Bluesky run UIDs for each completed acquisition, in order.
         These can be used to retrieve raw data from a Tiled or databroker
         catalog for post-hoc analysis.
@@ -50,7 +50,7 @@ class OptimizationResult:
 
     iterations_completed: int
     num_points: int
-    run_uids: tuple[str, ...]
+    uids: tuple[str, ...]
 
 
 class ConsumerCallback(CallbackBase):
@@ -233,14 +233,14 @@ class _OptimizationState:
     current_iteration: int = 0
     current_suggestions: list[dict] = field(default_factory=list)
     current_uid: str | None = None
-    run_uids: list[str] = field(default_factory=list)
+    uids: list[str] = field(default_factory=list)
 
     def build_result(self) -> OptimizationResult:
         """Build an :class:`OptimizationResult` from the current state."""
         return OptimizationResult(
-            iterations_completed=len(self.run_uids),
+            iterations_completed=len(self.uids),
             num_points=self.num_points,
-            run_uids=tuple(self.run_uids),
+            uids=tuple(self.uids),
         )
 
 
@@ -406,7 +406,7 @@ class QueueserverOptimizationRunner:
             result = (
                 self._state.build_result()
                 if self._state is not None
-                else OptimizationResult(iterations_completed=0, num_points=0, run_uids=())
+                else OptimizationResult(iterations_completed=0, num_points=0, uids=())
             )
             self._resolve_future(result)
         logger.info("Optimization stopped")
@@ -496,7 +496,7 @@ class QueueserverOptimizationRunner:
                 raise RuntimeError(f"Acquisition run {start_doc['uid']!r} ended with status {exit_status!r}: {reason}")
             logger.info(f"Acquisition complete for uid: {self._state.current_uid}")
             suggestions = self._state.current_suggestions
-            self._state.run_uids.append(start_doc["uid"])
+            self._state.uids.append(start_doc["uid"])
 
         # Evaluate the results
         outcomes = self._problem.evaluation_function(uid=start_doc["uid"], suggestions=suggestions)

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -323,7 +323,6 @@ def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):
     assert agent.actuators == [dof1.actuator, dof2.actuator]
     assert agent.evaluation_function == mock_evaluation_function
     assert agent.acquisition_plan is None
-    assert not agent.is_running
     assert agent.current_iteration == 0
     assert isinstance(agent.ax_client, Client)
 

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -16,7 +16,7 @@ from blop.queueserver import (
 @pytest.fixture(scope="function")
 def mock_optimization_problem():
     """Create a mock OptimizationProblem with necessary components."""
-    mock_optimizer = MagicMock()
+    mock_optimizer = MagicMock(spec=Optimizer)
     mock_optimizer.suggest.return_value = [
         {"_id": 0, "motor1": 5.0, "motor2": 3.0},
     ]
@@ -545,7 +545,6 @@ def test_runner_error_does_not_call_register_failures_when_optimizer_lacks_suppo
     _fire_callback(runner, mock_client, 0)
 
     assert future.exception() is not None
-    mock_optimization_problem.optimizer.register_failures.assert_not_called()
 
 
 def test_runner_error_in_ingest_sets_future_exception(mock_optimization_problem):
@@ -619,7 +618,6 @@ def test_runner_plan_failure_does_not_call_register_failures_when_unsupported(mo
 
     assert future.done()
     assert isinstance(future.exception(), RuntimeError)
-    mock_optimization_problem.optimizer.register_failures.assert_not_called()
 
 
 def test_runner_stop_races_final_callback_does_not_raise(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -297,7 +297,7 @@ def test_runner_stop_returns_partial_result(mock_optimization_problem):
     result = future.result()
     assert isinstance(result, OptimizationResult)
     assert result.iterations_completed == 0
-    assert result.run_uids == ()
+    assert result.uids == ()
 
 
 def test_runner_submit_suggestions_to_queueserver():
@@ -447,11 +447,11 @@ def test_runner_run_full_cycle(mock_optimization_problem):
     future = runner.run(iterations=3, num_points=2)
 
     # Simulate 3 acquisition completions by invoking the captured callback
-    run_uids = []
+    uids = []
     for i in range(3):
         current_uid = runner._state.current_uid
         uid = f"fake-uid-{i}"
-        run_uids.append(uid)
+        uids.append(uid)
         start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
         stop_doc = {"uid": "other-fake-uid", "run_start": uid, "exit_status": "success"}
         mock_client._on_stop(start_doc, stop_doc)
@@ -467,7 +467,7 @@ def test_runner_run_full_cycle(mock_optimization_problem):
     assert isinstance(result, OptimizationResult)
     assert result.iterations_completed == 3
     assert result.num_points == 2
-    assert result.run_uids == tuple(run_uids)
+    assert result.uids == tuple(uids)
 
 
 def test_runner_on_acquisition_complete_uid_mismatch_sets_future_exception(mock_optimization_problem):
@@ -572,7 +572,7 @@ def test_runner_future_resolves_none_on_successful_run(mock_optimization_problem
     result = future.result()
     assert isinstance(result, OptimizationResult)
     assert result.iterations_completed == 1
-    assert result.run_uids == ("fake-uid-0",)
+    assert result.uids == ("fake-uid-0",)
 
 
 @pytest.mark.parametrize("exit_status", ["fail", "abort"])

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -262,6 +262,7 @@ def test_runner_run_twice_fails():
         optimization_problem=mock_optimization_problem,
         queueserver_client=mock_client,
     )
+    assert runner.optimization_problem == mock_optimization_problem
 
     runner.run(iterations=1, num_points=1)
     submit_event.wait(timeout=5)
@@ -292,8 +293,8 @@ def test_runner_stop_returns_partial_result(mock_optimization_problem):
     runner.stop()
 
     assert future.done()
-    mock_client.stop_listener.assert_called()
-    assert future.done()
+    # TODO: possible stopping bug in remote dispatcher
+    mock_client.stop_listener.assert_not_called()
     result = future.result()
     assert isinstance(result, OptimizationResult)
     assert result.iterations_completed == 0
@@ -484,7 +485,6 @@ def test_runner_on_acquisition_complete_uid_mismatch_sets_future_exception(mock_
     exc = future.exception()
     assert isinstance(exc, RuntimeError)
     assert "current_uid did not match start document" in str(exc)
-    assert future.done()
 
 
 def test_runner_private_method_calls_before_run(mock_optimization_problem):
@@ -514,7 +514,6 @@ def test_runner_error_in_evaluation_function_sets_future_exception(mock_optimiza
 
     assert future.done()
     assert future.exception() is error
-    assert future.done()
 
 
 def test_runner_error_calls_register_failures_when_optimizer_supports_it():
@@ -559,7 +558,6 @@ def test_runner_error_in_ingest_sets_future_exception(mock_optimization_problem)
 
     assert future.done()
     assert future.exception() is error
-    assert future.done()
 
 
 def test_runner_future_resolves_none_on_successful_run(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -411,9 +411,7 @@ def _make_runner_with_captured_callback(mock_optimization_problem, iterations=3)
     return runner, mock_client, future
 
 
-def _fire_callback(
-    runner, mock_client, iteration: int, exit_status: str = "success", reason: str = ""
-) -> None:
+def _fire_callback(runner, mock_client, iteration: int, exit_status: str = "success", reason: str = "") -> None:
     """Fire the on_stop callback with a matching start/stop document pair."""
     current_uid = runner._state.current_uid
     uid = f"fake-uid-{iteration}"

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -411,12 +411,14 @@ def _make_runner_with_captured_callback(mock_optimization_problem, iterations=3)
     return runner, mock_client, future
 
 
-def _fire_callback(runner, mock_client, iteration: int) -> None:
+def _fire_callback(
+    runner, mock_client, iteration: int, exit_status: str = "success", reason: str = ""
+) -> None:
     """Fire the on_stop callback with a matching start/stop document pair."""
     current_uid = runner._state.current_uid
     uid = f"fake-uid-{iteration}"
     start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
-    stop_doc = {"uid": f"stop-{iteration}", "run_start": uid}
+    stop_doc = {"uid": f"stop-{iteration}", "run_start": uid, "exit_status": exit_status, "reason": reason}
     mock_client._on_stop(start_doc, stop_doc)
 
 
@@ -453,7 +455,7 @@ def test_runner_run_full_cycle(mock_optimization_problem):
         uid = f"fake-uid-{i}"
         run_uids.append(uid)
         start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
-        stop_doc = {"uid": "other-fake-uid", "run_start": uid}
+        stop_doc = {"uid": "other-fake-uid", "run_start": uid, "exit_status": "success"}
         mock_client._on_stop(start_doc, stop_doc)
 
     assert mock_client.submit_plan.call_count == 3
@@ -573,6 +575,55 @@ def test_runner_future_resolves_none_on_successful_run(mock_optimization_problem
     assert isinstance(result, OptimizationResult)
     assert result.iterations_completed == 1
     assert result.run_uids == ("fake-uid-0",)
+
+
+@pytest.mark.parametrize("exit_status", ["fail", "abort"])
+def test_runner_plan_failure_sets_future_exception(mock_optimization_problem, exit_status):
+    """A failed/aborted plan stores a RuntimeError in the future."""
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem, iterations=3)
+    _fire_callback(runner, mock_client, 0)  # one success
+    _fire_callback(runner, mock_client, 1, exit_status=exit_status, reason="hardware fault")
+
+    assert future.done()
+    exc = future.exception()
+    assert isinstance(exc, RuntimeError)
+    assert exit_status in str(exc)
+    assert "hardware fault" in str(exc)
+
+
+@pytest.mark.parametrize("exit_status", ["fail", "abort"])
+def test_runner_plan_failure_calls_register_failures_when_supported(exit_status):
+    """register_failures is called on TrialFaultAware optimizers when a plan fails."""
+
+    class FaultAwareOptimizer(Optimizer, TrialFaultAware): ...
+
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(spec=FaultAwareOptimizer),
+        actuators=["motor1"],
+        sensors=["detector"],
+        evaluation_function=MagicMock(),
+    )
+    mock_optimization_problem.optimizer.suggest.return_value = [{"_id": 0, "motor1": 5.0}]
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0, exit_status=exit_status, reason="beam lost")
+
+    assert future.done()
+    assert isinstance(future.exception(), RuntimeError)
+    mock_optimization_problem.optimizer.register_failures.assert_called_once()
+
+
+@pytest.mark.parametrize("exit_status", ["fail", "abort"])
+def test_runner_plan_failure_does_not_call_register_failures_when_unsupported(mock_optimization_problem, exit_status):
+    """register_failures is NOT called on optimizers that don't implement TrialFaultAware."""
+    assert not isinstance(mock_optimization_problem.optimizer, TrialFaultAware)
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0, exit_status=exit_status)
+
+    assert future.done()
+    assert isinstance(future.exception(), RuntimeError)
+    mock_optimization_problem.optimizer.register_failures.assert_not_called()
 
 
 def test_runner_stop_races_final_callback_does_not_raise(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -3,8 +3,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from blop.protocols import CanRegisterSuggestions, Optimizer, QueueserverOptimizationProblem
-from blop.queueserver import CORRELATION_UID_KEY, ConsumerCallback, QueueserverClient, QueueserverOptimizationRunner
+from blop.protocols import CanRegisterSuggestions, Optimizer, QueueserverOptimizationProblem, TrialFaultAware
+from blop.queueserver import (
+    CORRELATION_UID_KEY,
+    ConsumerCallback,
+    OptimizationResult,
+    QueueserverClient,
+    QueueserverOptimizationRunner,
+)
 
 
 @pytest.fixture(scope="function")
@@ -222,7 +228,7 @@ def test_runner_run_submits_suggestions_to_queueserver():
     )
     assert runner.optimization_problem == mock_optimization_problem
 
-    runner.run(iterations=1, num_points=1)
+    future = runner.run(iterations=1, num_points=1)
 
     # Verify optimizer.suggest was called
     mock_optimization_problem.optimizer.suggest.assert_called_once_with(1)
@@ -231,6 +237,9 @@ def test_runner_run_submits_suggestions_to_queueserver():
     mock_client.submit_plan.assert_called_once()
     submitted_plan = mock_client.submit_plan.call_args[0][0]
     assert submitted_plan.name == "my_acquire"
+
+    # Future should be pending (acquisition callback has not fired)
+    assert not future.done()
 
 
 def test_runner_run_twice_fails():
@@ -253,7 +262,6 @@ def test_runner_run_twice_fails():
         optimization_problem=mock_optimization_problem,
         queueserver_client=mock_client,
     )
-    assert runner.optimization_problem == mock_optimization_problem
 
     runner.run(iterations=1, num_points=1)
     submit_event.wait(timeout=5)
@@ -268,22 +276,28 @@ def test_runner_run_twice_fails():
         runner.submit_suggestions(suggestions)
 
 
-def test_runner_stop_sets_finished_state(mock_optimization_problem):
-    """Test stop() marks the runner as finished and stops listener."""
+def test_runner_stop_returns_partial_result(mock_optimization_problem):
+    """Test stop() marks the runner as finished, stops listener, and resolves the future."""
     mock_client = MagicMock(spec=QueueserverClient)
     runner = QueueserverOptimizationRunner(
         optimization_problem=mock_optimization_problem,
         queueserver_client=mock_client,
     )
 
-    # The acquisiton completion callback never fires here due to the mocked client, therefore
-    # the first plan runs forever
-    runner.run(10)
-    assert runner.is_running is True
+    # The acquisition completion callback never fires here due to the mocked client,
+    # so the first plan runs forever until stop() is called.
+    future = runner.run(10)
+    assert not future.done()
 
     runner.stop()
-    assert runner.is_running is False
+
+    assert future.done()
     mock_client.stop_listener.assert_called()
+    assert future.done()
+    result = future.result()
+    assert isinstance(result, OptimizationResult)
+    assert result.iterations_completed == 0
+    assert result.run_uids == ()
 
 
 def test_runner_submit_suggestions_to_queueserver():
@@ -305,7 +319,7 @@ def test_runner_submit_suggestions_to_queueserver():
     )
 
     suggestions = [{"motor1": 5}]
-    runner.submit_suggestions(suggestions)
+    future = runner.submit_suggestions(suggestions)
 
     # Verify optimizer.suggest was NOT called
     mock_optimization_problem.optimizer.suggest.assert_not_called()
@@ -315,6 +329,8 @@ def test_runner_submit_suggestions_to_queueserver():
     mock_client.submit_plan.assert_called_once()
     submitted_plan = mock_client.submit_plan.call_args[0][0]
     assert submitted_plan.name == "my_acquire"
+
+    assert not future.done()
 
 
 def test_runner_submit_suggestions_register_fails():
@@ -378,6 +394,32 @@ def test_runner_submit_suggestions_twice_fails():
         runner.run(iterations=1)
 
 
+def _make_runner_with_captured_callback(mock_optimization_problem, iterations=3):
+    """Helper: build a runner and capture the on_stop callback via start_listener side-effect."""
+    mock_client = MagicMock(spec=QueueserverClient)
+
+    def capture_callback(on_stop):
+        mock_client._on_stop = on_stop
+
+    mock_client.start_listener.side_effect = capture_callback
+
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+    future = runner.run(iterations=iterations, num_points=1)
+    return runner, mock_client, future
+
+
+def _fire_callback(runner, mock_client, iteration: int) -> None:
+    """Fire the on_stop callback with a matching start/stop document pair."""
+    current_uid = runner._state.current_uid
+    uid = f"fake-uid-{iteration}"
+    start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
+    stop_doc = {"uid": f"stop-{iteration}", "run_start": uid}
+    mock_client._on_stop(start_doc, stop_doc)
+
+
 def test_runner_run_full_cycle(mock_optimization_problem):
     """Test run() completes full suggest -> acquire -> ingest cycle across 3 iterations."""
     # Configure for num_points=2: suggest returns 2 items, evaluation_function returns 2 outcomes
@@ -402,12 +444,14 @@ def test_runner_run_full_cycle(mock_optimization_problem):
         queueserver_client=mock_client,
     )
 
-    runner.run(iterations=3, num_points=2)
+    future = runner.run(iterations=3, num_points=2)
 
     # Simulate 3 acquisition completions by invoking the captured callback
+    run_uids = []
     for i in range(3):
         current_uid = runner._state.current_uid
         uid = f"fake-uid-{i}"
+        run_uids.append(uid)
         start_doc = {"uid": uid, CORRELATION_UID_KEY: current_uid}
         stop_doc = {"uid": "other-fake-uid", "run_start": uid}
         mock_client._on_stop(start_doc, stop_doc)
@@ -416,31 +460,31 @@ def test_runner_run_full_cycle(mock_optimization_problem):
     assert mock_optimization_problem.optimizer.suggest.call_count == 3
     assert mock_optimization_problem.optimizer.ingest.call_count == 3
     assert mock_optimization_problem.evaluation_function.call_count == 3
-    assert runner.is_running is False
+
+    # Verify the future resolved with the correct result
+    assert future.done()
+    result = future.result()
+    assert isinstance(result, OptimizationResult)
+    assert result.iterations_completed == 3
+    assert result.num_points == 2
+    assert result.run_uids == tuple(run_uids)
 
 
-def test_runner_on_acquisition_complete_raises_on_uid_mismatch(mock_optimization_problem):
-    """Test _on_acquisition_complete raises RuntimeError when blop_correlation_uid does not match."""
-    mock_client = MagicMock(spec=QueueserverClient)
+def test_runner_on_acquisition_complete_uid_mismatch_sets_future_exception(mock_optimization_problem):
+    """Test _on_acquisition_complete stores error in future on UID mismatch."""
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
 
-    def capture_callback(on_stop):
-        mock_client._on_stop = on_stop
-
-    mock_client.start_listener.side_effect = capture_callback
-
-    runner = QueueserverOptimizationRunner(
-        optimization_problem=mock_optimization_problem,
-        queueserver_client=mock_client,
-    )
-
-    runner.run(iterations=1, num_points=1)
-
-    # Callback with wrong blop_correlation_uid should raise
     start_doc = {"uid": "fake-uid", CORRELATION_UID_KEY: "wrong-uid"}
     stop_doc = {"uid": "other-fake-uid", "run_start": "fake-uid"}
 
-    with pytest.raises(RuntimeError, match="current_uid did not match start document"):
-        mock_client._on_stop(start_doc, stop_doc)
+    # Should NOT raise — exception is captured in the future
+    mock_client._on_stop(start_doc, stop_doc)
+
+    assert future.done()
+    exc = future.exception()
+    assert isinstance(exc, RuntimeError)
+    assert "current_uid did not match start document" in str(exc)
+    assert future.done()
 
 
 def test_runner_private_method_calls_before_run(mock_optimization_problem):
@@ -453,5 +497,91 @@ def test_runner_private_method_calls_before_run(mock_optimization_problem):
     with pytest.raises(RuntimeError, match="run()"):
         runner._build_plan([{}])
 
-    with pytest.raises(RuntimeError, match="run()"):
-        runner._on_acquisition_complete({}, {})
+    # _on_acquisition_complete catches the error and stores it in the future;
+    # since there is no active future yet, verify the runner handles this gracefully.
+    runner._on_acquisition_complete({}, {})  # type: ignore[arg-type]
+    # No future to check, but the runner must not crash the caller's thread.
+    assert runner._current_future is None
+
+
+def test_runner_error_in_evaluation_function_sets_future_exception(mock_optimization_problem):
+    """Exception in evaluation_function stops the loop and stores the error in the future."""
+    error = ValueError("bad data")
+    mock_optimization_problem.evaluation_function.side_effect = error
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0)
+
+    assert future.done()
+    assert future.exception() is error
+    assert future.done()
+
+
+def test_runner_error_calls_register_failures_when_optimizer_supports_it():
+    """register_failures is called on TrialFaultAware optimizers when an error occurs."""
+
+    class FaultAwareOptimizer(Optimizer, TrialFaultAware): ...
+
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(spec=FaultAwareOptimizer),
+        actuators=["motor1", "motor2"],
+        sensors=["detector"],
+        evaluation_function=MagicMock(side_effect=RuntimeError("boom")),
+    )
+    mock_optimization_problem.optimizer.suggest.return_value = [{"_id": 0, "motor1": 5.0, "motor2": 3.0}]
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0)
+
+    assert future.exception() is not None
+    mock_optimization_problem.optimizer.register_failures.assert_called_once()
+
+
+def test_runner_error_does_not_call_register_failures_when_optimizer_lacks_support(mock_optimization_problem):
+    """register_failures is NOT called on optimizers that don't implement TrialFaultAware."""
+    mock_optimization_problem.evaluation_function.side_effect = RuntimeError("boom")
+    assert not isinstance(mock_optimization_problem.optimizer, TrialFaultAware)
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0)
+
+    assert future.exception() is not None
+    mock_optimization_problem.optimizer.register_failures.assert_not_called()
+
+
+def test_runner_error_in_ingest_sets_future_exception(mock_optimization_problem):
+    """Exception in optimizer.ingest stops the loop and stores the error in the future."""
+    error = RuntimeError("ingest failed")
+    mock_optimization_problem.optimizer.ingest.side_effect = error
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    _fire_callback(runner, mock_client, 0)
+
+    assert future.done()
+    assert future.exception() is error
+    assert future.done()
+
+
+def test_runner_future_resolves_none_on_successful_run(mock_optimization_problem):
+    """Future resolves to an OptimizationResult (not an exception) after a clean run."""
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem, iterations=1)
+    _fire_callback(runner, mock_client, 0)
+
+    assert future.done()
+    assert future.exception() is None
+    result = future.result()
+    assert isinstance(result, OptimizationResult)
+    assert result.iterations_completed == 1
+    assert result.run_uids == ("fake-uid-0",)
+
+
+def test_runner_stop_races_final_callback_does_not_raise(mock_optimization_problem):
+    """stop() called just after the last iteration completes does not raise InvalidStateError."""
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem, iterations=1)
+
+    # Fire the final callback — this resolves the future
+    _fire_callback(runner, mock_client, 0)
+    assert future.done()
+
+    # stop() should be safe to call even though the future is already resolved
+    runner.stop()  # Must not raise

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -536,6 +536,35 @@ def test_runner_error_calls_register_failures_when_optimizer_supports_it():
     mock_optimization_problem.optimizer.register_failures.assert_called_once()
 
 
+def test_runner_register_failures_raises_original_error_preserved_in_future():
+    """If register_failures() itself raises, the original acquisition error is still in the future."""
+
+    class FaultAwareOptimizer(Optimizer, TrialFaultAware): ...
+
+    acquisition_error = RuntimeError("evaluation failed")
+    register_error = RuntimeError("register_failures exploded")
+
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(spec=FaultAwareOptimizer),
+        actuators=["motor1"],
+        sensors=["detector"],
+        evaluation_function=MagicMock(side_effect=acquisition_error),
+    )
+    mock_optimization_problem.optimizer.suggest.return_value = [{"_id": 0, "motor1": 5.0}]
+    mock_optimization_problem.optimizer.register_failures.side_effect = register_error
+
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem, iterations=1)
+
+    # register_failures re-raises after logging, so it propagates out of the callback
+    with pytest.raises(RuntimeError, match="register_failures exploded"):
+        _fire_callback(runner, mock_client, 0)
+
+    assert future.done()
+    # The original acquisition error is what the caller sees
+    assert future.exception() is acquisition_error
+    mock_optimization_problem.optimizer.register_failures.assert_called_once()
+
+
 def test_runner_error_does_not_call_register_failures_when_optimizer_lacks_support(mock_optimization_problem):
     """register_failures is NOT called on optimizers that don't implement TrialFaultAware."""
     mock_optimization_problem.evaluation_function.side_effect = RuntimeError("boom")
@@ -630,3 +659,46 @@ def test_runner_stop_races_final_callback_does_not_raise(mock_optimization_probl
 
     # stop() should be safe to call even though the future is already resolved
     runner.stop()  # Must not raise
+
+
+@pytest.mark.parametrize("failing_method", ["start_listener", "submit_plan"])
+def test_runner_run_submit_error_fails_future_and_reraises(mock_optimization_problem, failing_method):
+    """An exception from start_listener or submit_plan in run() fails the future and re-raises."""
+    error = RuntimeError("connection refused")
+    mock_client = MagicMock(spec=QueueserverClient)
+    getattr(mock_client, failing_method).side_effect = error
+
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    with pytest.raises(RuntimeError, match="connection refused"):
+        runner.run(iterations=1, num_points=1)
+
+    future = runner._current_future
+    assert future is not None
+    assert future.done()
+    assert future.exception() is error
+
+
+@pytest.mark.parametrize("failing_method", ["start_listener", "submit_plan"])
+def test_runner_submit_suggestions_submit_error_fails_future_and_reraises(mock_optimization_problem, failing_method):
+    """An exception from start_listener or submit_plan in submit_suggestions() fails the future and re-raises."""
+    error = RuntimeError("connection refused")
+    mock_client = MagicMock(spec=QueueserverClient)
+    getattr(mock_client, failing_method).side_effect = error
+
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    suggestions = [{"_id": 0, "motor1": 1.0}]
+    with pytest.raises(RuntimeError, match="connection refused"):
+        runner.submit_suggestions(suggestions)
+
+    future = runner._current_future
+    assert future is not None
+    assert future.done()
+    assert future.exception() is error


### PR DESCRIPTION
Yet another refactor of the queuserver integration...

Closes #304 

# Summary

Tracking the optimization progress was annoying because you had to poll `agent.is_running`. There was also zero failure handling so when things went wrong it was impossible to tell and it looks like the run just got stuck somewhere.

Now we are properly handling the asynchronous nature of the queueserver integration by using `concurrent.futures`. We set exceptions when they occur. We have something that can block until the run is complete (no more polling!). And it now atuomatically registers failures with the optimizers than can handle them.

I also update the tutorial to use the future instead of the polling loop. I add to the docs reference all of the queueserver runner stuff as well.