### PR TITLE
Add plan keyword arguments to queueserver optimization problems

### DIFF
--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -602,7 +602,7 @@ class QueueserverAgent(_AxAgentMixin):
     blop.ax.dof.ChoiceDOF : For discrete parameters.
     blop.ax.objective.Objective : For defining objectives.
     blop.ax.optimizer.AxOptimizer : The optimizer used internally.
-    blop.queueserver.QueueservverOptimizatonRunner : Runner that handles interaction with bluesky-queueserver.
+    blop.queueserver.QueueserverOptimizatonRunner : Runner that handles interaction with bluesky-queueserver.
     """
 
     def __init__(
@@ -617,6 +617,7 @@ class QueueserverAgent(_AxAgentMixin):
         dof_constraints: Sequence[DOFConstraint] | None = None,
         outcome_constraints: Sequence[OutcomeConstraint] | None = None,
         checkpoint_path: str | None = None,
+        acquisition_plan_kwargs: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ):
         self._sensors = sensors
@@ -629,6 +630,7 @@ class QueueserverAgent(_AxAgentMixin):
                     self._actuators.append(dof.actuator)
         self._evaluation_function = evaluation_function
         self._acquisition_plan = acquisition_plan
+        self._acquisition_plan_kwargs = acquisition_plan_kwargs or {}
         self._optimizer = AxOptimizer(
             parameters=[dof.to_ax_parameter_config() for dof in dofs],
             objective=to_ax_objective_str(objectives),
@@ -674,6 +676,7 @@ class QueueserverAgent(_AxAgentMixin):
             sensors=self._sensors,
             evaluation_function=self._evaluation_function,
             acquisition_plan=self._acquisition_plan,
+            acquisition_plan_kwargs=self._acquisition_plan_kwargs,
         )
 
     def run(self, iterations: int = 1, n_points: int = 1) -> Future[OptimizationResult]:

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -290,6 +290,7 @@ class BaseOptimizationProblem(Generic[TActuator, TSensor, TPlan]):
     acquisition_plan: TPlan | None = None
 
 
+@dataclass(frozen=True)
 class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionPlan]):
     """
     An optimization problem to solve. Immutable once initialized.
@@ -321,6 +322,7 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
     ...
 
 
+@dataclass(frozen=True)
 class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     """
     An optimization problem to solve. Immutable once initialized.
@@ -342,8 +344,10 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     evaluation_function: EvaluationFunction
         A callable to evaluate data from a Bluesky run and produce outcomes.
     acquisition_plan: str, optional
-        The name of a Bluesky plan to acquire data from the beamline. If not provided, a default plan name will be used.
+        The name of a Bluesky plan to acquire data. If not provided, a default plan name will be used.
         The plan must match the arguments of :ref:`AcquisitionPlan`.
+    acquisition_plan_kwargs: Mapping[str, Any], optional
+        Additional plan arguments to pass to the Bluesky plan.
 
     See Also
     --------
@@ -351,4 +355,4 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     blop.queueserver.QueueserverOptimizationRunner : Runs the optimization loop using the bluesky-queueserver-api.
     """
 
-    ...
+    acquisition_plan_kwargs: Mapping[str, Any] | None = None

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -259,8 +259,6 @@ class QueueserverOptimizationRunner:
         sensors, and evaluation function.
     queueserver_client : QueueserverClient
         Client for communicating with the queueserver.
-    acquisition_plan_name : str
-        Name of the acquisition plan registered in the queueserver.
     """
 
     def __init__(
@@ -462,6 +460,7 @@ class QueueserverOptimizationRunner:
             list(self._problem.actuators),
             list(self._problem.sensors),
             md=md,
+            **(self._problem.acquisition_plan_kwargs or {}),
         )
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -333,6 +333,22 @@ def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):
     assert problem.evaluation_function == mock_evaluation_function
 
 
+def test_queueserver_agent_init_acquisition_plan_kwargs(mock_re_manager_api, mock_evaluation_function):
+    dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
+    agent = QueueserverAgent(
+        mock_re_manager_api,
+        "inproc://test",
+        ["det"],
+        [dof1],
+        [Objective(name="obj1", minimize=False)],
+        mock_evaluation_function,
+        acquisition_plan_kwargs={"exposure_time": 0.5, "num_frames": 10},
+    )
+
+    problem = agent.to_optimization_problem()
+    assert problem.acquisition_plan_kwargs == {"exposure_time": 0.5, "num_frames": 10}
+
+
 def test_queueserver_agent_init_actuator_instance(mock_re_manager_api, mock_evaluation_function):
     movable1 = MovableSignal(name="test_movable1")
     dof1 = RangeDOF(actuator=movable1, bounds=(0, 10), parameter_type="float")

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -242,6 +242,29 @@ def test_runner_run_submits_suggestions_to_queueserver():
     assert not future.done()
 
 
+def test_runner_run_passes_acquisition_plan_kwargs_to_bplan():
+    """Test that acquisition_plan_kwargs are forwarded to the submitted BPlan."""
+    mock_client = MagicMock(spec=QueueserverClient)
+    mock_optimization_problem = QueueserverOptimizationProblem(
+        optimizer=MagicMock(),
+        actuators=["motor1"],
+        sensors=["det"],
+        evaluation_function=MagicMock(),
+        acquisition_plan="my_acquire",
+        acquisition_plan_kwargs={"exposure_time": 0.5, "num_frames": 10},
+    )
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    runner.run(iterations=1, num_points=1)
+
+    submitted_plan = mock_client.submit_plan.call_args[0][0]
+    assert submitted_plan.kwargs["exposure_time"] == 0.5
+    assert submitted_plan.kwargs["num_frames"] == 10
+
+
 def test_runner_run_twice_fails():
     """Test 2 calls to run() fails."""
     submit_event = threading.Event()


### PR DESCRIPTION
Small oversight on how remote execution differs from in-process. In-process (with the `RE`) can always add additional arguments and wrap with `functools.partial`, but this can't happen through remote execution with queueserver. Therefore, we need to allow for keyword arguments for plans.

I also took this opportunity to clean up some related docstrings.