### PR TITLE
Replace ZMQ address argument with RemoteDispatcher for queueserver

### DIFF
--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -92,6 +92,7 @@ Once the containers are up, proceed with the tutorial below.
 ```{code-cell} ipython3
 import time
 
+from bluesky.callbacks.zmq import RemoteDispatcher
 from bluesky_queueserver_api.zmq import REManagerAPI
 
 RM = REManagerAPI(zmq_control_addr="tcp://localhost:60615")
@@ -264,13 +265,15 @@ class HimmelblauEvaluation:
 Now we bring everything together. The `QueueserverAgent` needs:
 
 - `re_manager_api`: how to communicate with the queueserver (submit plans, check status)
-- `zmq_consumer_addr`: where to listen for document completion events
+- `document_dispatcher`: a `RemoteDispatcher` that subscribes to the Bluesky document stream
 - The DOFs, objectives, sensors, and evaluation function
 
 ```{code-cell} ipython3
+document_dispatcher = RemoteDispatcher(("localhost", 5578))
+
 agent = QueueserverAgent(
     re_manager_api=RM,
-    zmq_consumer_addr=("localhost", 5578),
+    document_dispatcher=document_dispatcher,
     sensors=sensors,
     dofs=dofs,
     objectives=objectives,
@@ -282,8 +285,9 @@ agent = QueueserverAgent(
 ```{note}
 The `re_manager_api` argument also accepts an HTTP-based client
 (`bluesky_queueserver_api.http.REManagerAPI`) for deployments that expose the
-queueserver over HTTP rather than ZMQ. The `zmq_consumer_addr` points to the
-ZMQ proxy output port (5578) where Bluesky documents are published.
+queueserver over HTTP rather than ZMQ. Construct the `RemoteDispatcher` with
+whatever arguments your document stream requires, such as a ZMQ address or
+message prefix.
 ```
 
 ## Running the Optimization

--- a/docs/wip/qserver-experiment.md
+++ b/docs/wip/qserver-experiment.md
@@ -241,6 +241,7 @@ from blop.protocols import EvaluationFunction
 from tiled.client.container import Container
 from tiled.queries import Eq
 from blop.ax import QueueserverAgent 
+from bluesky.callbacks.zmq import RemoteDispatcher
 import numpy as np
 
 class DetectorEvaluation(EvaluationFunction):
@@ -288,6 +289,8 @@ Finally we put everything together, instantiate the agent and start an optimizat
 
 ```{code-cell} ipython3
 
+document_dispatcher = RemoteDispatcher(("localhost", 5578))
+
 agent = QueueserverAgent(
     sensors=sensors,                                # The list of sensors to read from
     dofs=dofs,                                      # The list of DOFs to search over 
@@ -296,8 +299,7 @@ agent = QueueserverAgent(
     acquisition_plan= "acquire",                    # The name of the plan in the Queueserver environment
     Queueserver_control_addr="tcp://localhost:60615",
     Queueserver_info_addr="tcp://localhost:60625",
-    zmq_consumer_ip= "localhost",
-    zmq_consumer_port= "5578", 
+    document_dispatcher=document_dispatcher,
 )
 ```
 

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -17,6 +17,7 @@ else:
 # ===============================
 import bluesky.preprocessors as bpp
 from bluesky.callbacks import CallbackBase
+from bluesky.callbacks.zmq import RemoteDispatcher
 from bluesky.utils import MsgGenerator
 from bluesky_queueserver_api.zmq import REManagerAPI
 
@@ -571,9 +572,8 @@ class QueueserverAgent(_AxAgentMixin):
     ----------
     re_manager_api : REManagerAPI
         The manager API for interaction with Bluesky queueserver.
-    zmq_consumer_addr : str
-        A ZMQ address to consume Bluesky messages from, to react to plan execution on the
-        remote server.
+    document_dispatcher : RemoteDispatcher
+        Dispatcher for consuming Bluesky documents from the remote server.
     sensors : Sequence[str]
         The sensors to use for acquisition. These should be the minimal set
         of sensors that are needed to compute the objectives.
@@ -608,7 +608,7 @@ class QueueserverAgent(_AxAgentMixin):
     def __init__(
         self,
         re_manager_api: REManagerAPI,
-        zmq_consumer_addr: str,
+        document_dispatcher: RemoteDispatcher,
         sensors: Sequence[str],
         dofs: Sequence[DOF],
         objectives: Sequence[Objective],
@@ -643,7 +643,7 @@ class QueueserverAgent(_AxAgentMixin):
         )
         self._runner = QueueserverOptimizationRunner(
             self.to_optimization_problem(),
-            QueueserverClient(re_manager_api, zmq_consumer_addr),
+            QueueserverClient(re_manager_api, document_dispatcher),
         )
 
     @property

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -91,26 +91,24 @@ class QueueserverClient:
     """
     Handles communication with a Bluesky queueserver.
 
-    This class encapsulates all ZMQ and HTTP communication with the queueserver,
-    including plan submission and event listening.
+    This class encapsulates queueserver communication, including plan submission
+    and event listening.
 
     Parameters
     ----------
     re_manager_api : bluesky_queueserver_api.zmq.REManagerAPI
         Manager instance for communication with Bluesky Queueserver
-    zmq_consumer_addr : str
-        Address for ZMQ document consumer (e.g., "localhost:5578").
+    document_dispatcher : bluesky.callbacks.zmq.RemoteDispatcher
+        Dispatcher for the Bluesky document stream.
     """
 
     def __init__(
         self,
         re_manager_api: REManagerAPI,
-        zmq_consumer_addr: str,
+        document_dispatcher: RemoteDispatcher,
     ):
-        self._zmq_consumer_addr = zmq_consumer_addr
-
         self._rm = re_manager_api
-        self._dispatcher: RemoteDispatcher | None = None
+        self._dispatcher = document_dispatcher
         self._consumer_callback: ConsumerCallback | None = None
         self._listener_thread: threading.Thread | None = None
 
@@ -201,27 +199,24 @@ class QueueserverClient:
             logger.warning("Listener already running")
             return
 
-        dispatcher = RemoteDispatcher(self._zmq_consumer_addr)
         self._consumer_callback = ConsumerCallback(callback=on_stop)
-        dispatcher.subscribe(self._consumer_callback)
+        self._dispatcher.subscribe(self._consumer_callback)
 
-        logger.info("Starting ZMQ listener thread")
+        logger.info("Starting document listener thread")
         self._listener_thread = threading.Thread(
-            target=dispatcher.start,
-            name="qserver-zmq-consumer",
+            target=self._dispatcher.start,
+            name="qserver-document-consumer",
             daemon=True,
         )
         self._listener_thread.start()
-        self._dispatcher = dispatcher
 
     def stop_listener(self) -> None:
-        """Stop the ZMQ listener thread."""
-        if self._dispatcher is not None:
+        """Stop the document listener thread."""
+        if self._listener_thread is not None:
             self._dispatcher.stop()
-            self._dispatcher = None
         self._consumer_callback = None
         self._listener_thread = None
-        logger.info("Stopped ZMQ listener")
+        logger.info("Stopped document listener")
 
 
 @dataclass

--- a/src/blop/tests/ax/test_agent.py
+++ b/src/blop/tests/ax/test_agent.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from ax import Client
 from bluesky.callbacks import CallbackBase
+from bluesky.callbacks.zmq import RemoteDispatcher
 from bluesky_queueserver_api.zmq import REManagerAPI
 
 from blop.ax.agent import Agent, QueueserverAgent
@@ -29,6 +30,11 @@ def mock_acquisition_plan():
 @pytest.fixture(scope="function")
 def mock_re_manager_api():
     return MagicMock(spec=REManagerAPI)
+
+
+@pytest.fixture(scope="function")
+def mock_document_dispatcher():
+    return MagicMock(spec=RemoteDispatcher)
 
 
 def test_agent_init(mock_evaluation_function, mock_acquisition_plan):
@@ -308,12 +314,12 @@ def test_agent_scalarized_objective(mock_evaluation_function):
     )
 
 
-def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):
+def test_queueserver_agent_init(mock_re_manager_api, mock_document_dispatcher, mock_evaluation_function):
     dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
     dof2 = RangeDOF(actuator="test_motor2", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1, dof2],
         [Objective(name="obj1", minimize=False)],
@@ -333,11 +339,13 @@ def test_queueserver_agent_init(mock_re_manager_api, mock_evaluation_function):
     assert problem.evaluation_function == mock_evaluation_function
 
 
-def test_queueserver_agent_init_acquisition_plan_kwargs(mock_re_manager_api, mock_evaluation_function):
+def test_queueserver_agent_init_acquisition_plan_kwargs(
+    mock_re_manager_api, mock_document_dispatcher, mock_evaluation_function
+):
     dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1],
         [Objective(name="obj1", minimize=False)],
@@ -349,13 +357,13 @@ def test_queueserver_agent_init_acquisition_plan_kwargs(mock_re_manager_api, moc
     assert problem.acquisition_plan_kwargs == {"exposure_time": 0.5, "num_frames": 10}
 
 
-def test_queueserver_agent_init_actuator_instance(mock_re_manager_api, mock_evaluation_function):
+def test_queueserver_agent_init_actuator_instance(mock_re_manager_api, mock_document_dispatcher, mock_evaluation_function):
     movable1 = MovableSignal(name="test_movable1")
     dof1 = RangeDOF(actuator=movable1, bounds=(0, 10), parameter_type="float")
     dof2 = RangeDOF(actuator="test_movable2", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1, dof2],
         [Objective(name="obj1", minimize=False)],
@@ -368,19 +376,23 @@ def test_queueserver_agent_init_actuator_instance(mock_re_manager_api, mock_eval
 @patch("blop.ax.agent.QueueserverClient")
 @patch("blop.ax.agent.QueueserverOptimizationRunner")
 def test_queueserver_agent_run(
-    mock_queueserver_runner_cls, mock_queueserver_client_cls, mock_re_manager_api, mock_evaluation_function
+    mock_queueserver_runner_cls,
+    mock_queueserver_client_cls,
+    mock_re_manager_api,
+    mock_document_dispatcher,
+    mock_evaluation_function,
 ):
     dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
     dof2 = RangeDOF(actuator="test_motor2", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1, dof2],
         [Objective(name="obj1", minimize=False)],
         mock_evaluation_function,
     )
-    mock_queueserver_client_cls.assert_called_once()
+    mock_queueserver_client_cls.assert_called_once_with(mock_re_manager_api, mock_document_dispatcher)
     mock_queueserver_runner_cls.assert_called_once()
 
     agent.run()
@@ -390,19 +402,23 @@ def test_queueserver_agent_run(
 @patch("blop.ax.agent.QueueserverClient")
 @patch("blop.ax.agent.QueueserverOptimizationRunner")
 def test_queueserver_agent_submit_suggestions(
-    mock_queueserver_runner_cls, mock_queueserver_client_cls, mock_re_manager_api, mock_evaluation_function
+    mock_queueserver_runner_cls,
+    mock_queueserver_client_cls,
+    mock_re_manager_api,
+    mock_document_dispatcher,
+    mock_evaluation_function,
 ):
     dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
     dof2 = RangeDOF(actuator="test_motor2", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1, dof2],
         [Objective(name="obj1", minimize=False)],
         mock_evaluation_function,
     )
-    mock_queueserver_client_cls.assert_called_once()
+    mock_queueserver_client_cls.assert_called_once_with(mock_re_manager_api, mock_document_dispatcher)
     mock_queueserver_runner_cls.assert_called_once()
 
     suggestions = [{"test_motor1": 5, "test_motor2": 9}]
@@ -413,19 +429,23 @@ def test_queueserver_agent_submit_suggestions(
 @patch("blop.ax.agent.QueueserverClient")
 @patch("blop.ax.agent.QueueserverOptimizationRunner")
 def test_queueserver_agent_stop(
-    mock_queueserver_runner_cls, mock_queueserver_client_cls, mock_re_manager_api, mock_evaluation_function
+    mock_queueserver_runner_cls,
+    mock_queueserver_client_cls,
+    mock_re_manager_api,
+    mock_document_dispatcher,
+    mock_evaluation_function,
 ):
     dof1 = RangeDOF(actuator="test_motor1", bounds=(0, 10), parameter_type="float")
     dof2 = RangeDOF(actuator="test_motor2", bounds=(0, 10), parameter_type="float")
     agent = QueueserverAgent(
         mock_re_manager_api,
-        "inproc://test",
+        mock_document_dispatcher,
         ["det"],
         [dof1, dof2],
         [Objective(name="obj1", minimize=False)],
         mock_evaluation_function,
     )
-    mock_queueserver_client_cls.assert_called_once()
+    mock_queueserver_client_cls.assert_called_once_with(mock_re_manager_api, mock_document_dispatcher)
     mock_queueserver_runner_cls.assert_called_once()
 
     agent.stop()

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -2,6 +2,7 @@ import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bluesky.callbacks.zmq import RemoteDispatcher
 
 from blop.protocols import CanRegisterSuggestions, Optimizer, QueueserverOptimizationProblem, TrialFaultAware
 from blop.queueserver import (
@@ -11,6 +12,12 @@ from blop.queueserver import (
     QueueserverClient,
     QueueserverOptimizationRunner,
 )
+
+
+@pytest.fixture(scope="function")
+def mock_document_dispatcher():
+    """Create a mock document dispatcher."""
+    return MagicMock(spec=RemoteDispatcher)
 
 
 @pytest.fixture(scope="function")
@@ -64,39 +71,39 @@ def test_consumer_callback_clears_cache_after_stop():
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_check_environment_raises_when_not_ready(mock_re_manager):
+def test_queueserver_client_check_environment_raises_when_not_ready(mock_re_manager, mock_document_dispatcher):
     """Test check_environment raises RuntimeError when environment not open."""
     mock_re_manager.status.return_value = {"worker_environment_exists": False}
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
 
     with pytest.raises(RuntimeError, match="queueserver environment is not open"):
         client.check_environment()
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_check_devices_raises_for_missing_device(mock_re_manager):
+def test_queueserver_client_check_devices_raises_for_missing_device(mock_re_manager, mock_document_dispatcher):
     """Test check_devices_available raises ValueError for missing devices."""
     mock_re_manager.devices_allowed.return_value = {"devices_allowed": {"motor1": {}}}
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
 
     with pytest.raises(ValueError, match="Device 'motor2' is not available"):
         client.check_devices_available(["motor1", "motor2"])
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_check_plan_raises_for_missing_plan(mock_re_manager):
+def test_queueserver_client_check_plan_raises_for_missing_plan(mock_re_manager, mock_document_dispatcher):
     """Test check_plan_available raises ValueError for missing plan."""
     mock_re_manager.plans_allowed.return_value = {"plans_allowed": {"other_plan": {}}}
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
 
     with pytest.raises(ValueError, match="Plan 'my_plan' is not available"):
         client.check_plan_available("my_plan")
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_submit_plan_with_autostart(mock_re_manager):
+def test_queueserver_client_submit_plan_with_autostart(mock_re_manager, mock_document_dispatcher):
     """Test submit_plan adds item and starts queue when autostart=True."""
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
     mock_plan = MagicMock()
 
     client.submit_plan(mock_plan, autostart=True)
@@ -107,9 +114,9 @@ def test_queueserver_client_submit_plan_with_autostart(mock_re_manager):
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_submit_plan_without_autostart(mock_re_manager):
+def test_queueserver_client_submit_plan_without_autostart(mock_re_manager, mock_document_dispatcher):
     """Test submit_plan only adds item when autostart=False."""
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
     mock_plan = MagicMock()
 
     client.submit_plan(mock_plan, autostart=False)
@@ -119,80 +126,76 @@ def test_queueserver_client_submit_plan_without_autostart(mock_re_manager):
 
 
 @patch("blop.queueserver.threading.Thread")
-@patch("blop.queueserver.RemoteDispatcher")
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_start_listener(mock_re_manager, mock_dispatcher_cls, mock_thread_cls):
+def test_queueserver_client_start_listener(mock_re_manager, mock_thread_cls, mock_document_dispatcher):
     """Test start_listener creates dispatcher, subscribes callback, and starts thread."""
     mock_re_manager.status.return_value = {"worker_environment_exists": True}
     mock_re_manager.devices_allowed.return_value = {"devices_allowed": {"motor1": {}, "detector": {}}}
     mock_re_manager.plans_allowed.return_value = {"plans_allowed": {"default_acquire": {}}}
 
-    client = QueueserverClient(mock_re_manager, "tcp://localhost:5578")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
     mock_callback = MagicMock()
 
     client.start_listener(on_stop=mock_callback)
 
-    mock_dispatcher_cls.assert_called_once_with("tcp://localhost:5578")
-    mock_dispatcher = mock_dispatcher_cls.return_value
-    mock_dispatcher.subscribe.assert_called_once()
-    subscribed_callback = mock_dispatcher.subscribe.call_args[0][0]
+    mock_document_dispatcher.subscribe.assert_called_once()
+    subscribed_callback = mock_document_dispatcher.subscribe.call_args[0][0]
     assert isinstance(subscribed_callback, ConsumerCallback)
     assert subscribed_callback._callback is mock_callback
 
     mock_thread_cls.assert_called_once()
     call_kwargs = mock_thread_cls.call_args[1]
-    assert call_kwargs["target"] == mock_dispatcher.start
+    assert call_kwargs["target"] == mock_document_dispatcher.start
     mock_thread_cls.return_value.start.assert_called_once()
 
 
 @patch("blop.queueserver.threading.Thread")
-@patch("blop.queueserver.RemoteDispatcher")
 @patch("blop.queueserver.REManagerAPI")
 def test_queueserver_client_start_listener_already_running_returns_early(
-    mock_re_manager, mock_dispatcher_cls, mock_thread_cls
+    mock_re_manager, mock_thread_cls, mock_document_dispatcher
 ):
     """Test start_listener returns early when listener is already running."""
     mock_re_manager.status.return_value = {"worker_environment_exists": True}
     mock_re_manager.devices_allowed.return_value = {"devices_allowed": {"motor1": {}, "detector": {}}}
     mock_re_manager.plans_allowed.return_value = {"plans_allowed": {"default_acquire": {}}}
 
-    client = QueueserverClient(mock_re_manager, "tcp://localhost:5578")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
     client._listener_thread = MagicMock()  # Simulate already running
 
     client.start_listener(on_stop=MagicMock())
 
-    mock_dispatcher_cls.assert_not_called()
+    mock_document_dispatcher.subscribe.assert_not_called()
     mock_thread_cls.assert_not_called()
 
 
 @patch("blop.queueserver.threading.Thread")
-@patch("blop.queueserver.RemoteDispatcher")
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_stop_listener(mock_re_manager, mock_dispatcher_cls, mock_thread_cls):
+def test_queueserver_client_stop_listener(mock_re_manager, mock_thread_cls, mock_document_dispatcher):
     """Test stop_listener stops dispatcher and clears state."""
     mock_re_manager.status.return_value = {"worker_environment_exists": True}
     mock_re_manager.devices_allowed.return_value = {"devices_allowed": {"motor1": {}, "detector": {}}}
     mock_re_manager.plans_allowed.return_value = {"plans_allowed": {"default_acquire": {}}}
 
-    client = QueueserverClient(mock_re_manager, "tcp://localhost:5578")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
     client.start_listener(on_stop=MagicMock())
 
     client.stop_listener()
 
-    mock_dispatcher_cls.return_value.stop.assert_called_once()
-    assert client._dispatcher is None
+    mock_document_dispatcher.stop.assert_called_once()
+    assert client._dispatcher is mock_document_dispatcher
     assert client._consumer_callback is None
     assert client._listener_thread is None
 
 
 @patch("blop.queueserver.REManagerAPI")
-def test_queueserver_client_stop_listener_when_not_started(mock_re_manager):
+def test_queueserver_client_stop_listener_when_not_started(mock_re_manager, mock_document_dispatcher):
     """Test stop_listener is safe to call when listener was never started."""
-    client = QueueserverClient(mock_re_manager, "inproc://test")
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
 
     client.stop_listener()  # Should not raise
 
-    assert client._dispatcher is None
+    mock_document_dispatcher.stop.assert_not_called()
+    assert client._dispatcher is mock_document_dispatcher
     assert client._listener_thread is None
 
 


### PR DESCRIPTION
# Summary

Currently the `QueueserverAgent`, `QueueserverOptimizationRunner`, and the `QueueserverClient` class all accept a ZMQ address as a string and eventually the client constructs a `RemoteDispatcher` internally using this address. This is a poor design since it doesn't allow for a user to use custom dispatchers or pass additional arguments to `RemoteDispatcher` (such as a prefix).

This PR replaces the ZMQ address argument with a document dispatcher argument that enables using an instance of a RemoteDispatcher that has already been configured.

# Breaking changes

- API change for the agent, runner, and client classes listed above