### PR TITLE
Stop publishing docs on scheduled workflow

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -2,6 +2,12 @@ name: Build Documentation
 
 on:
   workflow_call:
+    inputs:
+      publish:
+        description: "Whether to publish docs to gh-pages"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   build_docs:
@@ -47,7 +53,7 @@ jobs:
         run: python .github/pages/make_switcher.py --add $DOCS_VERSION ${{ github.repository }} .github/pages/switcher.json
 
       - name: Publish Docs to gh-pages
-        if: github.ref_type == 'tag' || github.ref_name == 'main'
+        if: inputs.publish && (github.ref_type == 'tag' || github.ref_name == 'main')
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     needs: lint
     if: needs.check.outputs.branch-pr == ''
     uses: ./.github/workflows/_docs.yml
+    with:
+      publish: ${{ github.event_name != 'schedule' }}
     permissions:
       contents: write
   


### PR DESCRIPTION
We were publishing the docs every morning to `gh-pages` from the scheduled workflow run. This PR should stop it, this way only pushes to main (from a PR) trigger the publish.