### PR TITLE
Start queueserver listener in runner init

### DIFF
--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -479,7 +479,7 @@ class QueueserverOptimizationRunner:
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""
-        
+
         try:
             self._process_acquisition(start_doc, stop_doc)
         except Exception as exc:
@@ -495,7 +495,6 @@ class QueueserverOptimizationRunner:
     def _process_acquisition(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Core acquisition-complete logic (called from _on_acquisition_complete)."""
 
-        
         with self._state_lock:
             if self._state is None:
                 raise RuntimeError("_on_acquisition_complete called before run()")

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -79,10 +79,17 @@ class ConsumerCallback(CallbackBase):
         super().__init__()
         self._start_doc_cache: RunStart | None = None
         self._callback = callback
+        self._start_doc_filter: Callable[[RunStart], bool] | None = None
+
+    def set_start_doc_filter(self, start_doc_filter: Callable[[RunStart], bool] | None) -> None:
+        """Set an optional predicate used to ignore unrelated start documents."""
+        self._start_doc_filter = start_doc_filter
 
     def start(self, doc: RunStart) -> None:
         """Caches the start document if it came from Blop"""
-        if doc.get(CORRELATION_UID_KEY, None):
+        if doc.get(CORRELATION_UID_KEY, None) and (
+            self._start_doc_filter is None or self._start_doc_filter(doc)
+        ):
             self._start_doc_cache = doc
         else:
             self._start_doc_cache = None
@@ -201,7 +208,11 @@ class QueueserverClient:
             response = self._rm.queue_start()
             logger.debug(f"Started queue. Response: {response}")
 
-    def start_listener(self, on_stop: Callable[[RunStart, RunStop], None]) -> None:
+    def start_listener(
+        self,
+        on_stop: Callable[[RunStart, RunStop], None],
+        start_doc_filter: Callable[[RunStart], bool] | None = None,
+    ) -> None:
         """
         Start listening for document events from the queueserver.
 
@@ -210,12 +221,15 @@ class QueueserverClient:
         on_stop : callable
             Callback invoked when a stop document is received.
             Signature: on_stop(start_doc, stop_doc)
+        start_doc_filter : callable, optional
+            Predicate used to ignore unrelated start documents before caching.
         """
         if self._listener_thread is not None:
             logger.warning("Listener already running")
             return
 
         self._consumer_callback = ConsumerCallback(callback=on_stop)
+        self._consumer_callback.set_start_doc_filter(start_doc_filter)
         self._dispatcher.subscribe(self._consumer_callback)
 
         logger.info("Starting document listener thread")
@@ -292,7 +306,10 @@ class QueueserverOptimizationRunner:
         self._autostart = True
         self._state_lock = threading.RLock()
         self._current_future: Future[OptimizationResult] | None = None
-        self._client.start_listener(on_stop=self._on_acquisition_complete)
+        self._client.start_listener(
+            on_stop=self._on_acquisition_complete,
+            start_doc_filter=self._is_expected_start_doc,
+        )
 
     @property
     def optimization_problem(self) -> QueueserverOptimizationProblem:
@@ -477,6 +494,11 @@ class QueueserverOptimizationRunner:
             md=md,
             **(self._problem.acquisition_plan_kwargs or {}),
         )
+
+    def _is_expected_start_doc(self, start_doc: RunStart) -> bool:
+        """Return True only for the acquisition currently expected by this runner."""
+        with self._state_lock:
+            return self._state is not None and self._state.current_uid == start_doc.get(CORRELATION_UID_KEY)
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -479,9 +479,7 @@ class QueueserverOptimizationRunner:
 
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""
-        with self._state_lock:
-            if self._state is None or self._state.current_uid != start_doc.get(CORRELATION_UID_KEY):
-                return
+        
         try:
             self._process_acquisition(start_doc, stop_doc)
         except Exception as exc:
@@ -496,12 +494,19 @@ class QueueserverOptimizationRunner:
 
     def _process_acquisition(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Core acquisition-complete logic (called from _on_acquisition_complete)."""
+
+        
         with self._state_lock:
             if self._state is None:
                 raise RuntimeError("_on_acquisition_complete called before run()")
             if self._state.current_uid is None:
                 raise RuntimeError("current_uid not set")
             exit_status = stop_doc.get("exit_status")
+            if self._state.current_uid != start_doc.get(CORRELATION_UID_KEY):
+                raise RuntimeError(
+                    "current_uid did not match start document. "
+                    f"Got: {start_doc.get(CORRELATION_UID_KEY)}, Expected: {self._state.current_uid}"
+                )
             if exit_status != "success":
                 reason = stop_doc.get("reason") or "(no reason given)"
                 raise RuntimeError(f"Acquisition run {start_doc['uid']!r} ended with status {exit_status!r}: {reason}")

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -87,9 +87,7 @@ class ConsumerCallback(CallbackBase):
 
     def start(self, doc: RunStart) -> None:
         """Caches the start document if it came from Blop"""
-        if doc.get(CORRELATION_UID_KEY, None) and (
-            self._start_doc_filter is None or self._start_doc_filter(doc)
-        ):
+        if doc.get(CORRELATION_UID_KEY, None) and (self._start_doc_filter is None or self._start_doc_filter(doc)):
             self._start_doc_cache = doc
         else:
             self._start_doc_cache = None

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -275,6 +275,8 @@ class QueueserverOptimizationRunner:
         sensors, and evaluation function.
     queueserver_client : QueueserverClient
         Client for communicating with the queueserver.
+        The document listener is started once during runner construction so it
+        is ready before any submitted plan can emit documents.
     """
 
     def __init__(
@@ -290,6 +292,7 @@ class QueueserverOptimizationRunner:
         self._autostart = True
         self._state_lock = threading.RLock()
         self._current_future: Future[OptimizationResult] | None = None
+        self._client.start_listener(on_stop=self._on_acquisition_complete)
 
     @property
     def optimization_problem(self) -> QueueserverOptimizationProblem:
@@ -346,8 +349,6 @@ class QueueserverOptimizationRunner:
             future: Future[OptimizationResult] = Future()
             self._current_future = future
         try:
-            self._client.start_listener(on_stop=self._on_acquisition_complete)
-            # TODO: Need to wait for connection handshake here
             self._client.submit_plan(plan, autostart=self._autostart)
         except Exception as exc:
             with self._state_lock:
@@ -397,8 +398,6 @@ class QueueserverOptimizationRunner:
             future: Future[OptimizationResult] = Future()
             self._current_future = future
         try:
-            self._client.start_listener(on_stop=self._on_acquisition_complete)
-            # TODO: Need to wait for connection handshake here
             self._client.submit_plan(plan, autostart=self._autostart)
         except Exception as exc:
             with self._state_lock:

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -77,30 +77,19 @@ class ConsumerCallback(CallbackBase):
 
     def __init__(self, callback: Callable[[RunStart, RunStop], None] | None = None):
         super().__init__()
-        self._start_doc_cache: RunStart | None = None
+        self._start_doc_cache: dict[str, RunStart] = {}
         self._callback = callback
-        self._start_doc_filter: Callable[[RunStart], bool] | None = None
-
-    def set_start_doc_filter(self, start_doc_filter: Callable[[RunStart], bool] | None) -> None:
-        """Set an optional predicate used to ignore unrelated start documents."""
-        self._start_doc_filter = start_doc_filter
 
     def start(self, doc: RunStart) -> None:
         """Caches the start document if it came from Blop"""
-        if doc.get(CORRELATION_UID_KEY, None) and (self._start_doc_filter is None or self._start_doc_filter(doc)):
-            self._start_doc_cache = doc
-        else:
-            self._start_doc_cache = None
+        if doc.get(CORRELATION_UID_KEY):
+            self._start_doc_cache[doc["uid"]] = doc
 
     def stop(self, doc: RunStop) -> None:
         """Executes the callback if the cached start and stop document match"""
-        if (
-            self._callback is not None
-            and self._start_doc_cache is not None
-            and self._start_doc_cache["uid"] == doc["run_start"]
-        ):
-            self._callback(self._start_doc_cache, doc)
-        self._start_doc_cache = None
+        start_doc = self._start_doc_cache.pop(doc["run_start"], None)
+        if self._callback is not None and start_doc is not None:
+            self._callback(start_doc, doc)
 
 
 class QueueserverClient:
@@ -209,7 +198,6 @@ class QueueserverClient:
     def start_listener(
         self,
         on_stop: Callable[[RunStart, RunStop], None],
-        start_doc_filter: Callable[[RunStart], bool] | None = None,
     ) -> None:
         """
         Start listening for document events from the queueserver.
@@ -219,15 +207,12 @@ class QueueserverClient:
         on_stop : callable
             Callback invoked when a stop document is received.
             Signature: on_stop(start_doc, stop_doc)
-        start_doc_filter : callable, optional
-            Predicate used to ignore unrelated start documents before caching.
         """
         if self._listener_thread is not None:
             logger.warning("Listener already running")
             return
 
         self._consumer_callback = ConsumerCallback(callback=on_stop)
-        self._consumer_callback.set_start_doc_filter(start_doc_filter)
         self._dispatcher.subscribe(self._consumer_callback)
 
         logger.info("Starting document listener thread")
@@ -306,7 +291,6 @@ class QueueserverOptimizationRunner:
         self._current_future: Future[OptimizationResult] | None = None
         self._client.start_listener(
             on_stop=self._on_acquisition_complete,
-            start_doc_filter=self._is_expected_start_doc,
         )
 
     @property
@@ -493,13 +477,11 @@ class QueueserverOptimizationRunner:
             **(self._problem.acquisition_plan_kwargs or {}),
         )
 
-    def _is_expected_start_doc(self, start_doc: RunStart) -> bool:
-        """Return True only for the acquisition currently expected by this runner."""
-        with self._state_lock:
-            return self._state is not None and self._state.current_uid == start_doc.get(CORRELATION_UID_KEY)
-
     def _on_acquisition_complete(self, start_doc: RunStart, stop_doc: RunStop) -> None:
         """Callback when acquisition finishes. Ingest results and maybe continue."""
+        with self._state_lock:
+            if self._state is None or self._state.current_uid != start_doc.get(CORRELATION_UID_KEY):
+                return
         try:
             self._process_acquisition(start_doc, stop_doc)
         except Exception as exc:
@@ -519,11 +501,6 @@ class QueueserverOptimizationRunner:
                 raise RuntimeError("_on_acquisition_complete called before run()")
             if self._state.current_uid is None:
                 raise RuntimeError("current_uid not set")
-            if self._state.current_uid != start_doc.get(CORRELATION_UID_KEY):
-                raise RuntimeError(
-                    "current_uid did not match start document. "
-                    f"Got: {start_doc.get(CORRELATION_UID_KEY)}, Expected: {self._state.current_uid}"
-                )
             exit_status = stop_doc.get("exit_status")
             if exit_status != "success":
                 reason = stop_doc.get("reason") or "(no reason given)"

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -84,19 +84,19 @@ def test_consumer_callback_ignores_start_without_correlation_uid():
     mock_callback.assert_not_called()
 
 
-def test_consumer_callback_ignores_start_rejected_by_filter():
-    """Test ConsumerCallback ignores Blop start documents rejected by the predicate."""
+def test_consumer_callback_matches_stop_to_cached_start_by_run_uid():
+    """Test ConsumerCallback matches stops to the correct cached Blop start."""
     mock_callback = MagicMock()
     callback = ConsumerCallback(callback=mock_callback)
-    callback.set_start_doc_filter(lambda doc: doc[CORRELATION_UID_KEY] == "expected")
-    run_uid = "test-uid"
-    start_doc = {"uid": run_uid, CORRELATION_UID_KEY: "other"}
-    stop_doc = {"uid": "test-uid2", "run_start": run_uid}
+    start_doc_1 = {"uid": "run-1", CORRELATION_UID_KEY: "one"}
+    start_doc_2 = {"uid": "run-2", CORRELATION_UID_KEY: "two"}
+    stop_doc = {"uid": "stop-2", "run_start": "run-2"}
 
-    callback.start(start_doc)
+    callback.start(start_doc_1)
+    callback.start(start_doc_2)
     callback.stop(stop_doc)
 
-    mock_callback.assert_not_called()
+    mock_callback.assert_called_once_with(start_doc_2, stop_doc)
 
 
 @patch("blop.queueserver.REManagerAPI")
@@ -171,7 +171,6 @@ def test_queueserver_client_start_listener(mock_re_manager, mock_thread_cls, moc
     subscribed_callback = mock_document_dispatcher.subscribe.call_args[0][0]
     assert isinstance(subscribed_callback, ConsumerCallback)
     assert subscribed_callback._callback is mock_callback
-    assert subscribed_callback._start_doc_filter is None
 
     mock_thread_cls.assert_called_once()
     call_kwargs = mock_thread_cls.call_args[1]
@@ -264,9 +263,7 @@ def test_runner_run_submits_suggestions_to_queueserver():
     future = runner.run(iterations=1, num_points=1)
 
     # Verify listener is started once during runner construction, not per run
-    mock_client.start_listener.assert_called_once()
-    assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
-    assert mock_client.start_listener.call_args.kwargs["start_doc_filter"] == runner._is_expected_start_doc
+    mock_client.start_listener.assert_called_once_with(on_stop=runner._on_acquisition_complete)
 
     # Verify optimizer.suggest was called
     mock_optimization_problem.optimizer.suggest.assert_called_once_with(1)
@@ -384,9 +381,7 @@ def test_runner_submit_suggestions_to_queueserver():
     future = runner.submit_suggestions(suggestions)
 
     # Verify listener is started once during runner construction, not per submission
-    mock_client.start_listener.assert_called_once()
-    assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
-    assert mock_client.start_listener.call_args.kwargs["start_doc_filter"] == runner._is_expected_start_doc
+    mock_client.start_listener.assert_called_once_with(on_stop=runner._on_acquisition_complete)
 
     # Verify optimizer.suggest was NOT called
     mock_optimization_problem.optimizer.suggest.assert_not_called()
@@ -465,9 +460,8 @@ def _make_runner_with_captured_callback(mock_optimization_problem, iterations=3)
     """Helper: build a runner and capture the on_stop callback via start_listener side-effect."""
     mock_client = MagicMock(spec=QueueserverClient)
 
-    def capture_callback(on_stop, start_doc_filter=None):
+    def capture_callback(on_stop):
         mock_client._on_stop = on_stop
-        mock_client._start_doc_filter = start_doc_filter
 
     mock_client.start_listener.side_effect = capture_callback
 
@@ -502,9 +496,8 @@ def test_runner_run_full_cycle(mock_optimization_problem):
 
     mock_client = MagicMock(spec=QueueserverClient)
 
-    def capture_callback(on_stop, start_doc_filter=None):
+    def capture_callback(on_stop):
         mock_client._on_stop = on_stop
-        mock_client._start_doc_filter = start_doc_filter
 
     mock_client.start_listener.side_effect = capture_callback
 
@@ -542,28 +535,15 @@ def test_runner_run_full_cycle(mock_optimization_problem):
     assert result.uids == tuple(uids)
 
 
-def test_runner_on_acquisition_complete_uid_mismatch_sets_future_exception(mock_optimization_problem):
-    """Test _on_acquisition_complete stores error in future on UID mismatch."""
+def test_runner_on_acquisition_complete_ignores_other_blop_runs(mock_optimization_problem):
+    """Test _on_acquisition_complete ignores Blop documents for other correlation UIDs."""
     runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
 
     start_doc = {"uid": "fake-uid", CORRELATION_UID_KEY: "wrong-uid"}
     stop_doc = {"uid": "other-fake-uid", "run_start": "fake-uid"}
 
-    # Should NOT raise — exception is captured in the future
     mock_client._on_stop(start_doc, stop_doc)
 
-    assert future.done()
-    exc = future.exception()
-    assert isinstance(exc, RuntimeError)
-    assert "current_uid did not match start document" in str(exc)
-
-
-def test_runner_start_doc_filter_ignores_other_blop_runs(mock_optimization_problem):
-    """Test runner-level start filter rejects Blop documents for other correlation UIDs."""
-    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
-    start_doc = {"uid": "other-run", CORRELATION_UID_KEY: "wrong-uid"}
-
-    assert mock_client._start_doc_filter(start_doc) is False
     assert not future.done()
     mock_optimization_problem.evaluation_function.assert_not_called()
 

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -70,6 +70,35 @@ def test_consumer_callback_clears_cache_after_stop():
     assert mock_callback.call_count == 1
 
 
+def test_consumer_callback_ignores_start_without_correlation_uid():
+    """Test ConsumerCallback ignores non-Blop start documents."""
+    mock_callback = MagicMock()
+    callback = ConsumerCallback(callback=mock_callback)
+    run_uid = "test-uid"
+    start_doc = {"uid": run_uid}
+    stop_doc = {"uid": "test-uid2", "run_start": run_uid}
+
+    callback.start(start_doc)
+    callback.stop(stop_doc)
+
+    mock_callback.assert_not_called()
+
+
+def test_consumer_callback_ignores_start_rejected_by_filter():
+    """Test ConsumerCallback ignores Blop start documents rejected by the predicate."""
+    mock_callback = MagicMock()
+    callback = ConsumerCallback(callback=mock_callback)
+    callback.set_start_doc_filter(lambda doc: doc[CORRELATION_UID_KEY] == "expected")
+    run_uid = "test-uid"
+    start_doc = {"uid": run_uid, CORRELATION_UID_KEY: "other"}
+    stop_doc = {"uid": "test-uid2", "run_start": run_uid}
+
+    callback.start(start_doc)
+    callback.stop(stop_doc)
+
+    mock_callback.assert_not_called()
+
+
 @patch("blop.queueserver.REManagerAPI")
 def test_queueserver_client_check_environment_raises_when_not_ready(mock_re_manager, mock_document_dispatcher):
     """Test check_environment raises RuntimeError when environment not open."""
@@ -142,6 +171,7 @@ def test_queueserver_client_start_listener(mock_re_manager, mock_thread_cls, moc
     subscribed_callback = mock_document_dispatcher.subscribe.call_args[0][0]
     assert isinstance(subscribed_callback, ConsumerCallback)
     assert subscribed_callback._callback is mock_callback
+    assert subscribed_callback._start_doc_filter is None
 
     mock_thread_cls.assert_called_once()
     call_kwargs = mock_thread_cls.call_args[1]
@@ -236,6 +266,7 @@ def test_runner_run_submits_suggestions_to_queueserver():
     # Verify listener is started once during runner construction, not per run
     mock_client.start_listener.assert_called_once()
     assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
+    assert mock_client.start_listener.call_args.kwargs["start_doc_filter"] == runner._is_expected_start_doc
 
     # Verify optimizer.suggest was called
     mock_optimization_problem.optimizer.suggest.assert_called_once_with(1)
@@ -355,6 +386,7 @@ def test_runner_submit_suggestions_to_queueserver():
     # Verify listener is started once during runner construction, not per submission
     mock_client.start_listener.assert_called_once()
     assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
+    assert mock_client.start_listener.call_args.kwargs["start_doc_filter"] == runner._is_expected_start_doc
 
     # Verify optimizer.suggest was NOT called
     mock_optimization_problem.optimizer.suggest.assert_not_called()
@@ -433,8 +465,9 @@ def _make_runner_with_captured_callback(mock_optimization_problem, iterations=3)
     """Helper: build a runner and capture the on_stop callback via start_listener side-effect."""
     mock_client = MagicMock(spec=QueueserverClient)
 
-    def capture_callback(on_stop):
+    def capture_callback(on_stop, start_doc_filter=None):
         mock_client._on_stop = on_stop
+        mock_client._start_doc_filter = start_doc_filter
 
     mock_client.start_listener.side_effect = capture_callback
 
@@ -469,8 +502,9 @@ def test_runner_run_full_cycle(mock_optimization_problem):
 
     mock_client = MagicMock(spec=QueueserverClient)
 
-    def capture_callback(on_stop):
+    def capture_callback(on_stop, start_doc_filter=None):
         mock_client._on_stop = on_stop
+        mock_client._start_doc_filter = start_doc_filter
 
     mock_client.start_listener.side_effect = capture_callback
 
@@ -522,6 +556,16 @@ def test_runner_on_acquisition_complete_uid_mismatch_sets_future_exception(mock_
     exc = future.exception()
     assert isinstance(exc, RuntimeError)
     assert "current_uid did not match start document" in str(exc)
+
+
+def test_runner_start_doc_filter_ignores_other_blop_runs(mock_optimization_problem):
+    """Test runner-level start filter rejects Blop documents for other correlation UIDs."""
+    runner, mock_client, future = _make_runner_with_captured_callback(mock_optimization_problem)
+    start_doc = {"uid": "other-run", CORRELATION_UID_KEY: "wrong-uid"}
+
+    assert mock_client._start_doc_filter(start_doc) is False
+    assert not future.done()
+    mock_optimization_problem.evaluation_function.assert_not_called()
 
 
 def test_runner_private_method_calls_before_run(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -544,8 +544,10 @@ def test_runner_on_acquisition_complete_ignores_other_blop_runs(mock_optimizatio
 
     mock_client._on_stop(start_doc, stop_doc)
 
-    assert not future.done()
-    mock_optimization_problem.evaluation_function.assert_not_called()
+    assert future.done()
+    exc = future.exception()
+    assert isinstance(exc, RuntimeError)
+    assert "current_uid did not match start document" in str(exc)
 
 
 def test_runner_private_method_calls_before_run(mock_optimization_problem):

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -233,6 +233,10 @@ def test_runner_run_submits_suggestions_to_queueserver():
 
     future = runner.run(iterations=1, num_points=1)
 
+    # Verify listener is started once during runner construction, not per run
+    mock_client.start_listener.assert_called_once()
+    assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
+
     # Verify optimizer.suggest was called
     mock_optimization_problem.optimizer.suggest.assert_called_once_with(1)
 
@@ -347,6 +351,10 @@ def test_runner_submit_suggestions_to_queueserver():
 
     suggestions = [{"motor1": 5}]
     future = runner.submit_suggestions(suggestions)
+
+    # Verify listener is started once during runner construction, not per submission
+    mock_client.start_listener.assert_called_once()
+    assert mock_client.start_listener.call_args.kwargs["on_stop"] == runner._on_acquisition_complete
 
     # Verify optimizer.suggest was NOT called
     mock_optimization_problem.optimizer.suggest.assert_not_called()
@@ -471,6 +479,8 @@ def test_runner_run_full_cycle(mock_optimization_problem):
         queueserver_client=mock_client,
     )
 
+    mock_client.start_listener.assert_called_once()
+
     future = runner.run(iterations=3, num_points=2)
 
     # Simulate 3 acquisition completions by invoking the captured callback
@@ -484,6 +494,7 @@ def test_runner_run_full_cycle(mock_optimization_problem):
         mock_client._on_stop(start_doc, stop_doc)
 
     assert mock_client.submit_plan.call_count == 3
+    mock_client.start_listener.assert_called_once()
     assert mock_optimization_problem.optimizer.suggest.call_count == 3
     assert mock_optimization_problem.optimizer.ingest.call_count == 3
     assert mock_optimization_problem.evaluation_function.call_count == 3
@@ -687,12 +698,24 @@ def test_runner_stop_races_final_callback_does_not_raise(mock_optimization_probl
     runner.stop()  # Must not raise
 
 
-@pytest.mark.parametrize("failing_method", ["start_listener", "submit_plan"])
-def test_runner_run_submit_error_fails_future_and_reraises(mock_optimization_problem, failing_method):
-    """An exception from start_listener or submit_plan in run() fails the future and re-raises."""
+def test_runner_init_listener_error_reraises(mock_optimization_problem):
+    """An exception from start_listener in __init__ is re-raised."""
     error = RuntimeError("connection refused")
     mock_client = MagicMock(spec=QueueserverClient)
-    getattr(mock_client, failing_method).side_effect = error
+    mock_client.start_listener.side_effect = error
+
+    with pytest.raises(RuntimeError, match="connection refused"):
+        QueueserverOptimizationRunner(
+            optimization_problem=mock_optimization_problem,
+            queueserver_client=mock_client,
+        )
+
+
+def test_runner_run_submit_error_fails_future_and_reraises(mock_optimization_problem):
+    """An exception from submit_plan in run() fails the future and re-raises."""
+    error = RuntimeError("connection refused")
+    mock_client = MagicMock(spec=QueueserverClient)
+    mock_client.submit_plan.side_effect = error
 
     runner = QueueserverOptimizationRunner(
         optimization_problem=mock_optimization_problem,
@@ -708,12 +731,11 @@ def test_runner_run_submit_error_fails_future_and_reraises(mock_optimization_pro
     assert future.exception() is error
 
 
-@pytest.mark.parametrize("failing_method", ["start_listener", "submit_plan"])
-def test_runner_submit_suggestions_submit_error_fails_future_and_reraises(mock_optimization_problem, failing_method):
-    """An exception from start_listener or submit_plan in submit_suggestions() fails the future and re-raises."""
+def test_runner_submit_suggestions_submit_error_fails_future_and_reraises(mock_optimization_problem):
+    """An exception from submit_plan in submit_suggestions() fails the future and re-raises."""
     error = RuntimeError("connection refused")
     mock_client = MagicMock(spec=QueueserverClient)
-    getattr(mock_client, failing_method).side_effect = error
+    mock_client.submit_plan.side_effect = error
 
     runner = QueueserverOptimizationRunner(
         optimization_problem=mock_optimization_problem,


### PR DESCRIPTION
Starts the queueserver document listener once during `QueueserverOptimizationRunner` initialization instead of before each plan submission. This ensures the listener is already active before queueserver runs can emit their first documents. It tried to address the problem in #295. This is a stop gap until we move to TiledWebSockets.

Tests were updated to verify:

- `start_listener()` is called once at runner construction.
- `run()` and `submit_suggestions()` do not restart the listener.
- Multi-iteration runs keep using the same listener.
- Listener startup failures now raise during construction, while `submit_plan` failures still fail the active future and re-raise.