### PR TITLE
Rename StoppingConditions to SupportsStoppingCriteria

### DIFF
--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -17,7 +17,7 @@ from .protocols import (
     CanRegisterSuggestions,
     OptimizationProblem,
     Sensor,
-    StoppingConditions,
+    SupportsStoppingCriteria,
     TrialFaultAware,
 )
 from .utils import InferredReadable, _maybe_checkpoint, collect_optimization_metadata, route_suggestions
@@ -219,7 +219,7 @@ def optimize(
             # Perform a single step of the optimization
             uid, suggestions, outcomes = yield from optimize_step(optimization_problem, n_points, **kwargs)
 
-            if isinstance(optimization_problem.optimizer, StoppingConditions):
+            if isinstance(optimization_problem.optimizer, SupportsStoppingCriteria):
                 stop_now, stop_reason = optimization_problem.optimizer.should_stop()
                 if stop_now:
                     reason = stop_reason if stop_reason is not None else "No reason provided"

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -82,9 +82,9 @@ class TrialFaultAware(Protocol):
 
 
 @runtime_checkable
-class StoppingConditions(Protocol):
+class SupportsStoppingCriteria(Protocol):
     """
-    A protocol for optimizers that can evaluate global stopping criteria.
+    A protocol for optimizers that can evaluate stopping criteria.
 
     This allows optimization plans to terminate early through tolerance, max_iterations etc.
     """

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -11,7 +11,7 @@ from blop.protocols import (
     EvaluationFunction,
     OptimizationProblem,
     Optimizer,
-    StoppingConditions,
+    SupportsStoppingCriteria,
     TrialFaultAware,
 )
 
@@ -483,7 +483,7 @@ def test_acquire_baseline_from_current(RE):
 def test_optimize_max_number_of_iterations_before_stop(RE):
     """Tests that the optimization stops at a set number of iterations"""
 
-    class StoppingOptimizer(Optimizer, StoppingConditions): ...
+    class StoppingOptimizer(Optimizer, SupportsStoppingCriteria): ...
 
     optimizer = MagicMock(spec=StoppingOptimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
@@ -510,7 +510,7 @@ def test_optimize_max_number_of_iterations_before_stop(RE):
 def test_optimize_stop_condition_not_hit(RE):
     """Tests that optimization stops before stop condition is met"""
 
-    class StoppingOptimizer(Optimizer, StoppingConditions): ...
+    class StoppingOptimizer(Optimizer, SupportsStoppingCriteria): ...
 
     optimizer = MagicMock(spec=StoppingOptimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
@@ -535,7 +535,7 @@ def test_optimize_stop_condition_not_hit(RE):
 def test_optimize_stops_when_change_is_within_tolerance(RE):
     """Tests that the optimization stops when the change in objective value is within a specified tolerance."""
 
-    class ToleranceStopOptimizer(Optimizer, StoppingConditions):
+    class ToleranceStopOptimizer(Optimizer, SupportsStoppingCriteria):
         def __init__(self, tolerance: float):
             self.tolerance = tolerance
             self._last_value: float | None = None


### PR DESCRIPTION
Renaming `StoppingConditions` to be closer to the style of other protocol names like `CanRegisterSuggestions`.