### PR TITLE
Easier way to use `SupportsStoppingCriteria`

### DIFF
--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -9,6 +9,7 @@ from ax import Client, TOutcome, TParameterization
 from ax.analysis.plotly.surface.contour import ContourPlot
 from ax.core.analysis_card import AnalysisCardBase
 from ax.core.types import TParamValue
+from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
 from bluesky.callbacks import CallbackBase
 from bluesky.utils import MsgGenerator
 
@@ -227,6 +228,8 @@ class Agent(_AxAgentMixin):
         Constraints on outcomes to be satisfied during optimization.
     checkpoint_path : str | None, optional
         The path to the checkpoint file to save the optimizer's state to.
+    stopping_strategy : BaseGlobalStoppingStrategy | None, optional
+        A stopping strategy that decides when/if optimization should halt early.
     **kwargs : Any
         Additional keyword arguments to configure the Ax experiment.
 
@@ -257,6 +260,7 @@ class Agent(_AxAgentMixin):
         dof_constraints: Sequence[DOFConstraint] | None = None,
         outcome_constraints: Sequence[OutcomeConstraint] | None = None,
         checkpoint_path: str | None = None,
+        stopping_strategy: BaseGlobalStoppingStrategy | None = None,
         **kwargs: Any,
     ):
         if any(isinstance(dof.actuator, str) for dof in dofs):
@@ -276,6 +280,7 @@ class Agent(_AxAgentMixin):
             if outcome_constraints
             else None,
             checkpoint_path=checkpoint_path,
+            stopping_strategy=stopping_strategy,
             **kwargs,
         )
         self._readable_cache: dict[str, InferredReadable] = {}

--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -7,11 +7,12 @@ from ax import ChoiceParameterConfig, Client, RangeParameterConfig, TOutcome, TP
 from ax.core import MultiObjectiveOptimizationConfig
 from ax.core.parameter import ChoiceParameter, RangeParameter
 from ax.core.types import TParamValue
+from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
 
-from ..protocols import ID_KEY, CanRegisterSuggestions, Checkpointable, Optimizer, TrialFaultAware
+from ..protocols import ID_KEY, CanRegisterSuggestions, Checkpointable, Optimizer, SupportsStoppingCriteria, TrialFaultAware
 
 
-class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultAware):
+class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultAware, SupportsStoppingCriteria):
     """
     An optimizer that uses Ax as the backend for optimization and experiment tracking.
 
@@ -29,6 +30,11 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
         The outcome constraints to apply to the optimization.
     checkpoint_path : str | None, optional
         The path to the checkpoint file to save the optimizer's state to.
+    stopping_strategy : BaseGlobalStoppingStrategy | None, optional
+        An Ax global stopping strategy that decides when to halt optimization early.
+        When provided, the optimizer satisfies :class:`blop.protocols.SupportsStoppingCriteria`
+        and ``optimize`` will stop as soon as ``should_stop()`` returns ``True``.
+        When ``None`` (default), optimization always runs to the requested number of iterations.
     client_kwargs : dict[str, Any] | None, optional
         Additional keyword arguments to configure the Ax client.
     **kwargs : Any
@@ -47,11 +53,13 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
         parameter_constraints: Sequence[str] | None = None,
         outcome_constraints: Sequence[str] | None = None,
         checkpoint_path: str | None = None,
+        stopping_strategy: BaseGlobalStoppingStrategy | None = None,
         client_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         self._parameter_names = [parameter.name for parameter in parameters]
         self._checkpoint_path = checkpoint_path
+        self._stopping_strategy = stopping_strategy
         self._client = Client(**(client_kwargs or {}))
         self._client.configure_experiment(
             parameters=parameters,
@@ -63,6 +71,24 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
             outcome_constraints=outcome_constraints,
         )
         self._fixed_parameters = None
+
+    def should_stop(self) -> tuple[bool, str | None]:
+        """
+        Evaluate whether optimization should terminate early.
+
+        Returns ``(False, None)`` as default when no stopping strategy was provided.
+
+        Returns
+        -------
+        tuple[bool, str | None]
+            ``(stop_now, reason)``. If ``stop_now`` is ``True``, optimization halts.
+            ``reason`` is logged when provided.
+        """
+        if self._stopping_strategy is None:
+            return False, None
+        if isinstance(self._stopping_strategy, BaseGlobalStoppingStrategy):
+            return self._stopping_strategy.should_stop_optimization(experiment=self._client._experiment)
+        return self._stopping_strategy()
 
     @classmethod
     def from_checkpoint(cls, checkpoint_path: str) -> "AxOptimizer":

--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -31,10 +31,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
     checkpoint_path : str | None, optional
         The path to the checkpoint file to save the optimizer's state to.
     stopping_strategy : BaseGlobalStoppingStrategy | None, optional
-        An Ax global stopping strategy that decides when to halt optimization early.
-        When provided, the optimizer satisfies :class:`blop.protocols.SupportsStoppingCriteria`
-        and ``optimize`` will stop as soon as ``should_stop()`` returns ``True``.
-        When ``None`` (default), optimization always runs to the requested number of iterations.
+        A stopping strategy that decides when/if optimization should halt early.
     client_kwargs : dict[str, Any] | None, optional
         Additional keyword arguments to configure the Ax client.
     **kwargs : Any

--- a/src/blop/tests/ax/test_optimizer.py
+++ b/src/blop/tests/ax/test_optimizer.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from ax import ChoiceParameterConfig, RangeParameterConfig
 from ax.exceptions.core import UnsupportedError
+from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
 
 from blop.ax.optimizer import AxOptimizer
 
@@ -413,3 +414,36 @@ def test_ax_optimizer_should_stop_with_callable_strategy():
     assert should_stop is True
     assert reason == "test stop reason"
     stopping_strategy.assert_called_once()
+
+
+def test_ax_optimizer_should_stop_with_base_global_strategy():
+    """should_stop testing if it is an instance of BaseGlobalStoppingStrategy."""
+
+    class TestStoppingStrategy(BaseGlobalStoppingStrategy):
+        def __init__(self, min_trials: int = 1, inactive_when_pending_trials: bool = True) -> None:
+            super().__init__(min_trials=min_trials, inactive_when_pending_trials=inactive_when_pending_trials)
+
+        def _should_stop_optimization(self, experiment):
+            if len(experiment.trials) >= 2:
+                return (True, f"Reached {len(experiment.trials)} trials")
+            return (False, None)
+
+    optimizer = AxOptimizer(
+        parameters=[
+            RangeParameterConfig(name="x1", bounds=(-5.0, 5.0), parameter_type="float"),
+        ],
+        objective="y1",
+        stopping_strategy=TestStoppingStrategy(),
+    )
+
+    # should not stop
+    optimizer.ingest([{"x1": 0.5, "y1": 1.0}])
+    should_stop, reason = optimizer.should_stop()
+    assert should_stop is False
+    assert reason is None
+
+    # should stop
+    optimizer.ingest([{"x1": 0.6, "y1": 2.0}])
+    should_stop, reason = optimizer.should_stop()
+    assert should_stop is True
+    assert "2 trials" in reason

--- a/src/blop/tests/ax/test_optimizer.py
+++ b/src/blop/tests/ax/test_optimizer.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -379,3 +379,37 @@ def test_ax_optimizer_get_best_points_multi_objective():
         assert "x1" in params
         assert "y1" in metrics
         assert "y2" in metrics
+
+
+def test_ax_optimizer_should_stop_no_strategy():
+    """should_stop returns (False, None) when no stopping strategy is provided."""
+    optimizer = AxOptimizer(
+        parameters=[
+            RangeParameterConfig(name="x1", bounds=(-5.0, 5.0), parameter_type="float"),
+        ],
+        objective="y1",
+    )
+
+    should_stop, reason = optimizer.should_stop()
+
+    assert should_stop is False
+    assert reason is None
+
+
+def test_ax_optimizer_should_stop_with_callable_strategy():
+    """should_stop calls a callable stopping strategy and returns its result."""
+    stopping_strategy = MagicMock(return_value=(True, "test stop reason"))
+
+    optimizer = AxOptimizer(
+        parameters=[
+            RangeParameterConfig(name="x1", bounds=(-5.0, 5.0), parameter_type="float"),
+        ],
+        objective="y1",
+        stopping_strategy=stopping_strategy,
+    )
+
+    should_stop, reason = optimizer.should_stop()
+
+    assert should_stop is True
+    assert reason == "test stop reason"
+    stopping_strategy.assert_called_once()


### PR DESCRIPTION
A continuation of #337 to making `SupportsStoppingCriteria` easier to use for the Ax backend. 

Closes #226 