### PR TITLE
Remove unnecessary validation of allowed devices and plans

### DIFF
--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -156,44 +156,6 @@ class QueueserverClient:
         if status is None or not status.get("worker_environment_exists", False):
             raise RuntimeError("The queueserver environment is not open")
 
-    def check_devices_available(self, device_names: Sequence[str]) -> None:
-        """
-        Verify that all specified devices are available in the queueserver.
-
-        Parameters
-        ----------
-        device_names : Sequence[str]
-            Names of devices to check.
-
-        Raises
-        ------
-        ValueError
-            If any device is not available.
-        """
-        res = self._rm.devices_allowed()
-        allowed = res["devices_allowed"]
-        for name in device_names:
-            if name not in allowed:
-                raise ValueError(f"Device '{name}' is not available in the queueserver environment")
-
-    def check_plan_available(self, plan_name: str) -> None:
-        """
-        Verify that a plan is available in the queueserver.
-
-        Parameters
-        ----------
-        plan_name : str
-            Name of the plan to check.
-
-        Raises
-        ------
-        ValueError
-            If the plan is not available.
-        """
-        res = self._rm.plans_allowed()
-        if plan_name not in res["plans_allowed"]:
-            raise ValueError(f"Plan '{plan_name}' is not available in the queueserver environment")
-
     def submit_plan(self, plan: BPlan) -> None:
         """
         Submit a plan to the queueserver queue.
@@ -467,12 +429,6 @@ class QueueserverOptimizationRunner:
         if self._current_future is not None and not self._current_future.done():
             raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
-
-        # Collect device names from actuators and sensors
-        actuator_names = list(self._problem.actuators)
-        sensor_names = list(self._problem.sensors)
-        self._client.check_devices_available(actuator_names + sensor_names)
-        self._client.check_plan_available(self._plan_name)
 
     def _build_plan(self, suggestions: list[dict]) -> BPlan:
         """LOCKED: Build the plan to submit and update current state."""

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -14,7 +14,7 @@ a queueserver, rather than directly through a RunEngine.
 import logging
 import threading
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import Any, Literal

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -112,26 +112,6 @@ def test_queueserver_client_check_environment_raises_when_not_ready(mock_re_mana
 
 
 @patch("blop.queueserver.bluesky_queueserver_api.http.REManagerAPI")
-def test_queueserver_client_check_devices_raises_for_missing_device(mock_re_manager, mock_document_dispatcher):
-    """Test check_devices_available raises ValueError for missing devices."""
-    mock_re_manager.devices_allowed.return_value = {"devices_allowed": {"motor1": {}}}
-    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
-
-    with pytest.raises(ValueError, match="Device 'motor2' is not available"):
-        client.check_devices_available(["motor1", "motor2"])
-
-
-@patch("blop.queueserver.bluesky_queueserver_api.http.REManagerAPI")
-def test_queueserver_client_check_plan_raises_for_missing_plan(mock_re_manager, mock_document_dispatcher):
-    """Test check_plan_available raises ValueError for missing plan."""
-    mock_re_manager.plans_allowed.return_value = {"plans_allowed": {"other_plan": {}}}
-    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
-
-    with pytest.raises(ValueError, match="Plan 'my_plan' is not available"):
-        client.check_plan_available("my_plan")
-
-
-@patch("blop.queueserver.bluesky_queueserver_api.http.REManagerAPI")
 def test_queueserver_client_submit_plan_with_autostart(mock_re_manager, mock_document_dispatcher):
     """Test submit_plan adds item and starts queue when autostart=True."""
     client = QueueserverClient(mock_re_manager, mock_document_dispatcher, autostart=True)

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from bluesky.callbacks.zmq import RemoteDispatcher
+from bluesky_queueserver_api import BPlan
+from bluesky_queueserver_api.zmq import REManagerAPI
 
 from blop.protocols import CanRegisterSuggestions, Optimizer, QueueserverOptimizationProblem, TrialFaultAware
 from blop.queueserver import (
@@ -133,6 +135,31 @@ def test_queueserver_client_submit_plan_without_autostart(mock_re_manager, mock_
 
     mock_re_manager.queue_autostart.assert_called_once_with(False)
     mock_re_manager.item_add.assert_called_once_with(mock_plan)
+
+
+@patch("blop.queueserver.bluesky_queueserver_api.http.REManagerAPI")
+def test_queueserver_client_submit_plan_propagates_item_add_rejection(mock_re_manager, mock_document_dispatcher):
+    """Test submit_plan propagates queueserver item_add rejection unchanged."""
+    response = {
+        "success": False,
+        "msg": "Failed to add an item: plan rejected by RE Manager",
+        "qsize": None,
+        "item": None,
+    }
+    error = REManagerAPI.RequestFailedError(
+        request={"method": "queue_item_add"},
+        response=response,
+    )
+    mock_re_manager.item_add.side_effect = error
+    client = QueueserverClient(mock_re_manager, mock_document_dispatcher)
+    plan = BPlan("count", ["det_forbidden"], num=1)
+
+    with pytest.raises(REManagerAPI.RequestFailedError) as exc_info:
+        client.submit_plan(plan)
+
+    assert exc_info.value is error
+    assert exc_info.value.response is response
+    mock_re_manager.item_add.assert_called_once_with(plan)
 
 
 @patch("blop.queueserver.threading.Thread")


### PR DESCRIPTION
This error mode is already handled by the REManagerAPI and it propagates back up.

Closes #343 