### PR TITLE
Allow sepcifying 'actuator' and 'name' in Ax DOFs when 'actuator' is a string

### DIFF
--- a/src/blop/ax/dof.py
+++ b/src/blop/ax/dof.py
@@ -25,7 +25,7 @@ class DOF(ABC):
     Attributes
     ----------
     name : str | None
-        The name of the DOF. Provide a name if the DOF is not an actuator.
+        The name of the DOF.
     actuator : Actuator | str | None
         The actuator or its name to use for the DOF. Provide an actuator if the DOF is controllable by Bluesky.
 
@@ -37,10 +37,13 @@ class DOF(ABC):
 
     Notes
     -----
-    Either ``name`` or ``actuator`` must be provided, but not both. If ``actuator`` is
-    provided, the DOF will be associated with a Bluesky-controllable device and will
-    automatically move during acquisition. If only ``name`` is provided, the DOF
-    represents a parameter that is controlled externally.
+    If ``actuator`` is an ``Actuator`` device instance, the DOF will be associated with a
+    Bluesky-controllable device and will automatically move during acquisition.
+    If only ``name`` is provided, the DOF represents a parameter that is controlled externally.
+    Both ``name`` and ``actuator`` can be provided, but only if both are strings. This is
+    necessary when using bluesky-queueserver which requires ``actuator`` to be
+    the Python variable name for the device instance and ``name`` is the ``device.name``.
+    When both ``actuator`` and ``name`` are specified, the Ax parameter name will be ``name``.
     """
 
     name: str | None = None
@@ -48,15 +51,17 @@ class DOF(ABC):
 
     def __post_init__(self) -> None:
         """Ensure name and actuator are not both specified."""
-        if not (bool(self.name) ^ bool(self.actuator)):
-            raise ValueError("Either name or actuator must be provided, but not both or neither.")
+        if self.name is None and self.actuator is None:
+            raise ValueError("Either name or actuator must be provided.")
+        if isinstance(self.actuator, Actuator) and self.name is not None:
+            raise ValueError("Either name or actuator must be provided, but not both.")
 
     @property
     def parameter_name(self) -> str:
         """The parameter name used internally by Ax."""
         if isinstance(self.actuator, Actuator):
             param_name = self.actuator.name
-        elif isinstance(self.actuator, str):
+        elif self.name is None and isinstance(self.actuator, str):
             param_name = self.actuator
         else:
             param_name = cast(str, self.name)

--- a/src/blop/tests/ax/test_dof.py
+++ b/src/blop/tests/ax/test_dof.py
@@ -25,6 +25,14 @@ def test_dof_name():
     assert choice_dof.parameter_name == "test_name"
 
 
+def test_dof_actuator_and_name():
+    """Queueserver expects actuator to be Python variable name, but Ax needs the ``device.name``"""
+    range_dof = RangeDOF(actuator="test.sub1", name="test_sub1", bounds=(0, 1), parameter_type="float", step_size=0.1)
+    assert range_dof.parameter_name == "test_sub1"
+    choice_dof = ChoiceDOF(actuator="test.sub2", name="test_sub2", values=[0, 1, 2, 3, 4, 5], parameter_type="int")
+    assert choice_dof.parameter_name == "test_sub2"
+
+
 def test_dof_invalid():
     movable = MovableSignal(name="test_movable")
     with pytest.raises(ValueError):
@@ -35,6 +43,9 @@ def test_dof_invalid():
 
     with pytest.raises(TypeError):
         DOF(actuator=movable, name="test_movable")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError):
+        RangeDOF(bounds=(0, 1), parameter_type="float")
 
 
 def test_range_dof():


### PR DESCRIPTION
This is required for interaction with queueserver when trying to control components of allowed devices.

E.g. The actuator is `m2.roll` and `m2.roll.name == "m2-roll"`. You would specify:
```python
from blop.ax import RangeDOF
dof = RangeDOF(actuator="m2.roll", name="m2-roll", ...)
```

I raised this consistency issue in https://github.com/bluesky/bluesky-queueserver/issues/367 

Closes #345 