### PR TITLE
Protocol type relaxation

### DIFF
--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -25,28 +25,37 @@ association between optimizer suggestions and the acquired data within the
 chosen storage or event system (typically stashing the suggestions in proper 
 order in storage or tagging the run markdown).
 
+The plan must return a hashable acquisition identifier. Blop passes that value
+unchanged to the evaluation function. A Bluesky run UID is the usual identifier,
+but a tuple of event UIDs can identify acquisitions performed within one run.
+
 A simple example that optimizes in a subspace while executing measurements in
 the full physical coordinate system is shown below. 
 
 .. code-block:: python
 
+    from collections.abc import Hashable, Mapping, Sequence
+    from typing import Any
+
+    from bluesky.utils import MsgGenerator
+
     class SubspaceAcquisition(AcquisitionPlan):
 
         def __call__(
             self,
-            suggestions: list[dict],
+            suggestions: Sequence[Mapping],
             actuators: Sequence[Actuator],
             sensors: Sequence[Sensor] | None = None,
-            md: dict[str, Any] | None = None,
-        ) -> MsgGenerator[str]:
+            md: Mapping[str, Any] | None = None,
+        ) -> MsgGenerator[Hashable]:
 
             coords = [subspace_to_real(s) for s in suggestions]
-            yield from default_acquire(
+            return (yield from default_acquire(
                 coords,
                 actuators,
                 sensors=sensors,
                 md=md,
-            )
+            ))
 
 Wrapping the default acquire function is completely acceptable for coordinate to 
 coordinate schemes to keep default acquire's convenience. Just remember that 

--- a/docs/source/explanations/callbacks.rst
+++ b/docs/source/explanations/callbacks.rst
@@ -54,6 +54,10 @@ but the contents are optimization-focused.
     values, and outcome values. For batched optimization, these values may be
     arrays.
 
+For ``acquisition_uid``, native array-like identifiers such as a tuple of event
+UIDs are stored directly. Other hashable identifiers are stored using their
+``repr``; the evaluation function still receives the original identifier.
+
 ``stop``
     Completion status and reason, useful for summaries or cleanup.
 

--- a/docs/source/explanations/callbacks.rst
+++ b/docs/source/explanations/callbacks.rst
@@ -50,7 +50,7 @@ but the contents are optimization-focused.
     UIDs, and other values.
 
 ``event``
-    Per-step values such as ``suggestion_ids``, ``bluesky_uid``, parameter
+    Per-step values such as ``suggestion_ids``, ``acquisition_uid``, parameter
     values, and outcome values. For batched optimization, these values may be
     arrays.
 

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -4,19 +4,21 @@ The Evaluation Function
 The evaluation function is the primary interface between **blop** and your experimental data analysis pipeline. It is responsible for retrieving
 experimental data, performing any required post-processing, and computing the objective values returned to the optimizer.
 
-Rather than prescribing a particular processing framework or directly managing data, **blop** adopts a UID-driven workflow that mirrors the event-based processing patterns
-commonly used at beamlines. This design allows existing data handling and analysis code to be reused with minimal modification, reducing the need to
-reimplement processing logic specifically for optimization.
+Rather than prescribing a particular processing framework or directly managing data, **blop** uses an identifier-driven workflow. The acquisition
+plan returns a hashable identifier, and Blop passes that same identifier to the evaluation function. This mirrors event-based processing patterns
+commonly used at beamlines while also supporting data acquired within a single Bluesky run.
 
 
 Anatomy of an Evaluation Function
 ---------------------------------
 
-An evaluation function is simply a callable object that accepts a run UID, and a suggestion list and returns the objective values computed from the corresponding experimental data.
+An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
 
 A typical implementation is shown below:
 
 .. code-block:: python
+
+    from collections.abc import Hashable, Mapping, Sequence
 
     class GenericEvaluation(EvaluationFunction):
         """Inheriting from EvaluationFunction is optional but provides
@@ -32,16 +34,15 @@ A typical implementation is shown below:
             #   - Configuring optimization-specific parameters 
             #       - (perhaps varying of exponents in loss combinations, selecting between L1 and L2 norm...)
 
-        def __call__(self, uid, suggestions):
-            # Invoked by the RunEngine with the UID of an acquired run.
+        def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+            # Invoked with the identifier returned by the acquisition plan.
             #
             # Typical responsibilities include:
-            #   - Retrieving data associated with the UID
-            #   - Iterating over individual suggestions in the run 
-            #       - found in a run's start document under "blop_suggestions" when using default_aquire aquisition plan
+            #   - Retrieving the data associated with the identifier
+            #   - Iterating over individual suggestions in the acquisition
+            #       - found in a run's start document under "blop_suggestions" when using default_acquire
             #   - Constructing a per-suggestion analysis context
-            #   - Calling a lower-level objective function for each
-            #     sample or suggestion
+            #   - Calling a lower-level objective function for each sample or suggestion
 
 Although the interface is intentionally minimal, separating setup from
 execution is recommended.
@@ -51,8 +52,8 @@ execution is recommended.
     loading analysis resources, and configuring reusable analysis parameters.
 
 ``__call__``
-    Retrieve the data associated with a run UID, iterate over the individual
-    suggestions or samples, and orchestrate the analysis workflow.
+    Retrieve the data associated with the acquisition identifier, iterate over the
+    individual suggestions or samples, and orchestrate the analysis workflow.
 
 Where possible, keep the actual objective calculation in a separate function
 that operates on a single sample or suggestion. This separation makes the

--- a/docs/source/explanations/protocols.rst
+++ b/docs/source/explanations/protocols.rst
@@ -20,10 +20,10 @@ Data Flow
 
 The data flow for a typical optimization workflow is as follows:
 
-1. The optimizer suggests a set of points to evaluate.
-2. The acquisition plan is used to acquire data from the beamline.
-3. The evaluation function is used to transform the acquired data into outcomes.
-4. The outcomes are ingested by the optimizer to inform future suggestions.
+1. The optimizer suggests a sequence of mappings describing points to evaluate.
+2. The acquisition plan acquires data and returns a hashable acquisition identifier.
+3. Blop passes that identifier unchanged to the evaluation function, which transforms the acquired data into a sequence of outcome mappings.
+4. The optimizer ingests the outcomes to inform future suggestions.
 
 .. image:: ../_static/protocol-data-flow.png
    :alt: Data Flow Diagram

--- a/docs/source/how-to-guides/acquire-baseline.rst
+++ b/docs/source/how-to-guides/acquire-baseline.rst
@@ -99,6 +99,8 @@ Here we configure an agent with three DOFs and two objectives. The second object
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from blop.ax import Agent, RangeDOF, Objective, OutcomeConstraint
 
     dofs = [
@@ -114,7 +116,7 @@ Here we configure an agent with three DOFs and two objectives. The second object
 
     outcome_constraints = [OutcomeConstraint("x >= baseline", x=objectives[1])]
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/attach-data-to-experiments.rst
+++ b/docs/source/how-to-guides/attach-data-to-experiments.rst
@@ -104,6 +104,8 @@ The ``DOF`` and ``Objective`` names must match the keys in the data dictionaries
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from blop.ax import Agent, RangeDOF, Objective
 
     dofs = [
@@ -117,7 +119,7 @@ The ``DOF`` and ``Objective`` names must match the keys in the data dictionaries
         Objective(name="objective2", minimize=False),
     ]
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/custom-callbacks.rst
+++ b/docs/source/how-to-guides/custom-callbacks.rst
@@ -65,7 +65,9 @@
     motor_x = MovableSignal("motor_x")
     signal = ReadableSignal("signal")
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    from collections.abc import Hashable, Mapping, Sequence
+
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         outcomes = []
         for suggestion in suggestions:
             outcomes.append({

--- a/docs/source/how-to-guides/custom-generation-strategies.rst
+++ b/docs/source/how-to-guides/custom-generation-strategies.rst
@@ -97,6 +97,8 @@ Configure an agent
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from blop.ax import Agent, RangeDOF, Objective
 
     dofs = [
@@ -108,7 +110,7 @@ Configure an agent
         Objective(name="objective1", minimize=False),
     ]
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/manual-suggestions.rst
+++ b/docs/source/how-to-guides/manual-suggestions.rst
@@ -70,8 +70,10 @@
     motor_x = MovableSignal("motor_x")
     motor_y = MovableSignal("motor_y")
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     # Mock evaluation function for examples
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Mock evaluation function that returns constant outcomes."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/set-dof-constraints.rst
+++ b/docs/source/how-to-guides/set-dof-constraints.rst
@@ -77,6 +77,8 @@ Create DOFs and an objective
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from blop.ax import RangeDOF, Objective
 
     motor_x = MovableSignal(name="motor_x")
@@ -89,7 +91,7 @@ Create DOFs and an objective
 
     objective = Objective(name="objective1", minimize=False)
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/set-outcome-constraints.rst
+++ b/docs/source/how-to-guides/set-outcome-constraints.rst
@@ -84,6 +84,8 @@ Create DOFs and multiple objectives
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from blop.ax import RangeDOF, Objective
 
     motor_x = MovableSignal(name="motor_x")
@@ -102,7 +104,7 @@ Create DOFs and multiple objectives
         Objective(name="objective2", minimize=False),
     ]
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/use-ophyd-devices.rst
+++ b/docs/source/how-to-guides/use-ophyd-devices.rst
@@ -58,6 +58,9 @@ If you use a custom acquisition plan by implementing the :class:`blop.protocols.
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+    from typing import Any
+
     import bluesky.plan_stubs as bps
     from bluesky.utils import MsgGenerator
     from bluesky.run_engine import RunEngine
@@ -66,8 +69,14 @@ If you use a custom acquisition plan by implementing the :class:`blop.protocols.
     from blop.ax import Agent, RangeDOF, Objective
     from blop.protocols import AcquisitionPlan, Actuator, Sensor
 
-    def custom_acquire(suggestions: list[dict], actuators: list[Actuator], sensors: list[Sensor]) -> MsgGenerator[str]:
+    def custom_acquire(
+        suggestions: Sequence[Mapping],
+        actuators: Sequence[Actuator],
+        sensors: Sequence[Sensor] | None = None,
+        md: Mapping[str, Any] | None = None,
+    ) -> MsgGenerator[Hashable]:
         assert actuators[0].name == "signal1"
+        assert sensors is not None
         assert sensors[0].name == "signal2"
         yield from bps.null()
         return "test-uid-123"

--- a/docs/source/how-to-guides/use-tiled.rst
+++ b/docs/source/how-to-guides/use-tiled.rst
@@ -102,7 +102,7 @@ Creating an Evaluation Function
 To access data from Tiled within your evaluation function, create a class that:
 
 1. Accepts a client instance in its ``__init__`` method
-2. Implements a ``__call__`` method that retrieves data using the latest run UID
+2. Accepts the hashable acquisition identifier and validates that this default-acquisition example received a string run UID
 3. Processes the data to compute optimization objectives
 
 Evaluation Function with Tiled
@@ -112,14 +112,17 @@ Here's an example evaluation function that reads data from Tiled for where all d
 
 .. testcode::
 
+    from collections.abc import Hashable, Mapping, Sequence
+
     from tiled.client.container import Container
 
     class TiledEvaluation:
         def __init__(self, tiled_client: Container):
             self.tiled_client = tiled_client
 
-        def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
-            # Access the run data 
+        def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+            if not isinstance(uid, str):
+                raise TypeError(f"TiledEvaluation requires a Bluesky run UID string, got {uid!r}")
             run = self.tiled_client[uid]
             
             # Extract data columns

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -123,14 +123,18 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. After each run, Blop calls this function with the run's unique ID and the suggestions that were tried. It returns the computed objective values:
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
 
 ```{code-cell} ipython3
+from collections.abc import Hashable, Mapping, Sequence
+
 class Himmelblau2DEvaluation:
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+        if not isinstance(uid, str):
+            raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
         run = self.tiled_client[uid]
         outcomes = []
         reordered_suggestions = run.start["blop_suggestions"]

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -203,16 +203,13 @@ sensors = ["himmel_det"]
 
 ## Writing the Evaluation Function
 
-The evaluation function is called each time a plan completes. It reads data from Tiled and computes the objective values. The function receives:
-
-- `uid`: the Bluesky run UID (use this to look up data in Tiled)
-- `suggestions`: the list of parameter dicts that were evaluated
-
-It must return a list of outcome dicts, each containing the objective value(s) and an `_id` matching the suggestion.
+The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` matching the suggestion.
 
 Because the agent and the ZMQ-Tiled bridge are separate subscribers to the same ZMQ stream, there is a race condition: the agent may receive the stop document before the bridge has finished writing data to Tiled. The evaluation function should poll Tiled until both the run and the detector data are available.
 
 ```{code-cell} ipython3
+from collections.abc import Hashable, Mapping, Sequence
+
 import numpy as np
 from tiled.client.container import Container
 
@@ -251,7 +248,9 @@ class HimmelblauEvaluation:
             "The ZMQ-Tiled bridge may still be writing the run."
         )
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+        if not isinstance(uid, str):
+            raise TypeError(f"HimmelblauEvaluation requires a Bluesky run UID string, got {uid!r}")
         run = self._wait_for_run(uid)
 
         # Read the detector values from the primary data stream

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -115,14 +115,18 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. After each run, Blop calls this function with the run's unique ID and the suggestions that were tried. It returns the computed objective values:
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
 
 ```{code-cell} ipython3
+from collections.abc import Hashable, Mapping, Sequence
+
 class Himmelblau2DEvaluation():
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+        if not isinstance(uid, str):
+            raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
         run = self.tiled_client[uid]
         outcomes = []
         reordered_suggestions = run.start["blop_suggestions"]

--- a/docs/source/tutorials/xrt-demo.md
+++ b/docs/source/tutorials/xrt-demo.md
@@ -121,6 +121,8 @@ objectives = [
 ```
 
 ```{code-cell} ipython3
+from collections.abc import Hashable, Mapping, Sequence
+
 class DetectorEvaluation(EvaluationFunction):
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
@@ -190,7 +192,9 @@ class DetectorEvaluation(EvaluationFunction):
 
         return float(fwhm), float(intensity)
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+        if not isinstance(uid, str):
+            raise TypeError(f"DetectorEvaluation requires a Bluesky run UID string, got {uid!r}")
         outcomes = []
         run = self.tiled_client[uid]
 

--- a/docs/source/tutorials/xrt-kb-mirrors.md
+++ b/docs/source/tutorials/xrt-kb-mirrors.md
@@ -141,9 +141,9 @@ Using a single objective with an outcome constraint gives us the best of both wo
 
 ## Writing an Evaluation Function
 
-The **evaluation function** is the bridge between raw experimental data and the optimizer. After each measurement, the optimizer needs to know how well that configuration performed. Our evaluation function:
+The **evaluation function** is the bridge between raw experimental data and the optimizer. After each measurement, the optimizer needs to know how well that configuration performed. The general interface receives a hashable acquisition identifier; this tutorial uses the default acquisition plan, so that identifier is a Bluesky run UID. Our evaluation function:
 
-1. Receives a run UID and the suggestions that were tested
+1. Validates the run UID and receives the suggestions that were tested
 1. Reads the beam images from Tiled
 1. Computes FWHM from the marginal beam profiles
 1. Returns outcome values for each suggestion
@@ -151,6 +151,8 @@ The **evaluation function** is the bridge between raw experimental data and the 
 We compute FWHM using **marginal profiles** — projecting the 2D image onto each axis by summing, then finding where the 1D profile crosses half its peak value. This approach is robust to noise and dead pixels (they get averaged out in the projection) and doesn't require curve fitting.
 
 ```{code-cell} ipython3
+from collections.abc import Hashable, Mapping, Sequence
+
 class DetectorEvaluation(EvaluationFunction):
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
@@ -220,7 +222,9 @@ class DetectorEvaluation(EvaluationFunction):
 
         return float(fwhm), float(intensity)
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+        if not isinstance(uid, str):
+            raise TypeError(f"DetectorEvaluation requires a Bluesky run UID string, got {uid!r}")
         outcomes = []
         run = self.tiled_client[uid]
 

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -91,8 +91,8 @@ class _AxAgentMixin:
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries, each containing a parameterization of a point to
-            evaluate next. Each dictionary includes an "_id" key for identification.
+            A sequence of mappings, each containing a parameterization of a point to
+            evaluate next. Each mapping includes an "_id" key for identification.
         """
         return self._optimizer.suggest(num_points)
 
@@ -106,9 +106,9 @@ class _AxAgentMixin:
         Parameters
         ----------
         points : Sequence[Mapping]
-            A list of dictionaries, each containing outcomes for a trial. For suggested
-            points, include the "_id" key. For external data, include DOF names and
-            objective values, and omit "_id".
+            A sequence of mappings containing outcomes for a trial. For suggested points,
+            include the "_id" key. For external data, include DOF names and objective
+            values, and omit "_id".
 
         Notes
         -----
@@ -314,7 +314,7 @@ class Agent(_AxAgentMixin):
         sensors: Sequence[Sensor]
             Objects that can produce data to acquire data from the beamline using the Bluesky RunEngine.
         evaluation_function: EvaluationFunction
-            A callable to evaluate data from a Bluesky run and produce outcomes.
+            A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
         acquisition_plan: AcquisitionPlan, optional
             A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
         """
@@ -507,8 +507,8 @@ class Agent(_AxAgentMixin):
 
         Returns
         -------
-        tuple[str, Sequence[Mapping], Sequence[Mapping]]
-            Bluesky run UID, suggestions with "_id", and outcomes.
+        tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]
+            Acquisition identifier, suggestions with "_id", and outcomes.
 
         See Also
         --------

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -1,7 +1,7 @@
 """Agent interface for optimization with Ax as the backend."""
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from typing import Any, cast
 
 import bluesky.preprocessors as bpp
@@ -74,7 +74,7 @@ class _AxAgentMixin:
 
         self._optimizer.fixed_parameters = {dof.parameter_name: value for dof, value in fixed_dofs.items()}
 
-    def suggest(self, num_points: int = 1) -> list[dict]:
+    def suggest(self, num_points: int = 1) -> Sequence[Mapping]:
         """
         Get the next point(s) to evaluate in the search space.
 
@@ -90,13 +90,13 @@ class _AxAgentMixin:
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries, each containing a parameterization of a point to
             evaluate next. Each dictionary includes an "_id" key for identification.
         """
         return self._optimizer.suggest(num_points)
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """
         Ingest evaluation results into the optimizer.
 
@@ -105,7 +105,7 @@ class _AxAgentMixin:
 
         Parameters
         ----------
-        points : list[dict]
+        points : Sequence[Mapping]
             A list of dictionaries, each containing outcomes for a trial. For suggested
             points, include the "_id" key. For external data, include DOF names and
             objective values, and omit "_id".
@@ -119,7 +119,7 @@ class _AxAgentMixin:
         """
         self._optimizer.ingest(points)
 
-    def get_best_points(self) -> list[tuple[int, TParameterization, TOutcome]]:
+    def get_best_points(self) -> Sequence[tuple[int, TParameterization, TOutcome]]:
         """
         Get a list of the optimal points found during optimization.
 
@@ -128,7 +128,7 @@ class _AxAgentMixin:
 
         Returns
         -------
-        list[tuple[int, TParameterization, TOutcome]]
+        Sequence[tuple[int, TParameterization, TOutcome]]
             Each element in the list is a tuple of:
               - trial index (int)
               - parameter values (dict)
@@ -491,7 +491,9 @@ class Agent(_AxAgentMixin):
 
         yield from optimize_plan
 
-    def sample_suggestions(self, suggestions: list[dict]) -> MsgGenerator[tuple[str, list[dict], list[dict]]]:
+    def sample_suggestions(
+        self, suggestions: Sequence[Mapping]
+    ) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
         """
         Evaluate specific parameter combinations.
 
@@ -500,12 +502,12 @@ class Agent(_AxAgentMixin):
 
         Parameters
         ----------
-        suggestions : list[dict]
+        suggestions : Sequence[Mapping]
             Either optimizer suggestions (with "_id") or manual points (without "_id").
 
         Returns
         -------
-        tuple[str, list[dict], list[dict]]
+        tuple[str, Sequence[Mapping], Sequence[Mapping]]
             Bluesky run UID, suggestions with "_id", and outcomes.
 
         See Also

--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -1,6 +1,6 @@
 """An optimizer protocol implementation for Ax."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ax import ChoiceParameterConfig, Client, RangeParameterConfig, TOutcome, TParameterization
@@ -144,7 +144,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
             )
         self._fixed_parameters = dict(fixed_parameters)
 
-    def suggest(self, num_points: int | None = None) -> list[dict]:
+    def suggest(self, num_points: int | None = None) -> Sequence[Mapping]:
         """
         Get the next point(s) to evaluate in the search space.
 
@@ -158,7 +158,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries, each containing a parameterization of a point to
             evaluate next. Each dictionary includes an "_id" key for tracking.
         """
@@ -173,7 +173,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
             for trial_index, parameterization in next_trials.items()
         ]
 
-    def get_best_points(self) -> list[tuple[int, TParameterization, TOutcome]]:
+    def get_best_points(self) -> Sequence[tuple[int, TParameterization, TOutcome]]:
         """
         Get a list of the optimal points found during optimization.
 
@@ -182,7 +182,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         Returns
         -------
-        list[tuple[int, TParameterization, TOutcome]]
+        Sequence[tuple[int, TParameterization, TOutcome]]
             Each element in the list is a tuple of:
               - trial index (int)
               - parameter values (dict)
@@ -218,7 +218,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
                 outcomes[k] = v
         return parameters, outcomes
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """
         Ingest evaluation results into the optimizer.
 
@@ -227,7 +227,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         Parameters
         ----------
-        points : list[dict]
+        points : Sequence[Mapping]
             A list of dictionaries, each containing outcomes for a trial. For suggested
             points (from :meth:`suggest`), include the "_id" key. For external data,
             include parameter names and objective values, and omit "_id".
@@ -245,7 +245,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
                 trial_idx = self._client.attach_baseline(parameters=parameters)
             self._client.complete_trial(trial_index=trial_idx, raw_data=outcomes)
 
-    def register_suggestions(self, suggestions: list[dict]) -> list[dict]:
+    def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """
         Register manual suggestions with the Ax experiment.
 
@@ -255,12 +255,12 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         Parameters
         ----------
-        suggestions : list[dict]
+        suggestions : Sequence[Mapping]
             Parameter combinations to register. The "_id" key will be overwritten if present.
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             The same suggestions with "_id" keys added.
         """
         registered = []
@@ -277,7 +277,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         return registered
 
-    def register_failures(self, suggestions) -> None:
+    def register_failures(self, suggestions: Sequence[Mapping]) -> None:
         """
         Register suggestions as failures.
 
@@ -286,7 +286,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
 
         Parameters
         ----------
-        suggestions : list[dict]
+        suggestions : Sequence[Mapping]
             the trial id key must be present to pass back to the optimizer
         """
         for s in suggestions:

--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -159,8 +159,8 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries, each containing a parameterization of a point to
-            evaluate next. Each dictionary includes an "_id" key for tracking.
+            A sequence of mappings, each containing a parameterization of a point to
+            evaluate next. Each mapping includes an "_id" key for tracking.
         """
         if num_points is None:
             num_points = 1
@@ -228,9 +228,9 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
         Parameters
         ----------
         points : Sequence[Mapping]
-            A list of dictionaries, each containing outcomes for a trial. For suggested
-            points (from :meth:`suggest`), include the "_id" key. For external data,
-            include parameter names and objective values, and omit "_id".
+            A sequence of mappings containing outcomes for a trial. For suggested points
+            (from :meth:`suggest`), include the "_id" key. For external data, include
+            parameter names and objective values, and omit "_id".
 
         Notes
         -----

--- a/src/blop/ax/optimizer.py
+++ b/src/blop/ax/optimizer.py
@@ -205,7 +205,7 @@ class AxOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaultA
             params, metrics, trial_index, _ = self._client.get_best_parameterization(use_model_predictions=False)
             return [(trial_index, params, metrics)]
 
-    def _split_point(self, point: dict) -> tuple[dict, dict]:
+    def _split_point(self, point: Mapping) -> tuple[dict, dict]:
         """Split a point into parameters and outcomes."""
         parameters = {}
         outcomes = {}

--- a/src/blop/ax/queueserver_agent.py
+++ b/src/blop/ax/queueserver_agent.py
@@ -193,7 +193,7 @@ class QueueserverAgent(_AxAgentMixin):
         """
         return self._runner.run(iterations=iterations, num_points=n_points, checkpoint_interval=checkpoint_interval)
 
-    def submit_suggestions(self, suggestions: list[dict]) -> Future[OptimizationResult]:
+    def submit_suggestions(self, suggestions: Sequence[Mapping]) -> Future[OptimizationResult]:
         """
         Evaluate specific parameter combinations.
 
@@ -202,7 +202,7 @@ class QueueserverAgent(_AxAgentMixin):
 
         Parameters
         ----------
-        suggestions : list[dict]
+        suggestions : Sequence[Mapping]
             Either optimizer suggestions (with "_id") or manual points (without "_id").
 
         Returns

--- a/src/blop/callbacks/logger.py
+++ b/src/blop/callbacks/logger.py
@@ -178,9 +178,9 @@ class OptimizationLogger(CallbackBase):
         param_columns: dict[str, list] = {k: _to_list(data[k]) for k in parameter_keys if k in data}
         outcome_columns: dict[str, list] = {k: _to_list(data[k]) for k in outcome_keys if k in data}
 
-        # Extract suggestion IDs and acquisition UID
+        # Extract suggestion IDs and acquisition identifier
         suggestion_ids = _to_list(data.get("suggestion_ids", []))
-        acquire_uid = data.get("bluesky_uid", "")
+        acquire_uid = data.get("acquisition_uid", "")
         # Scalar string comes through as-is; ensure it's a plain string
         if isinstance(acquire_uid, list):
             acquire_uid = acquire_uid[0] if acquire_uid else ""

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -12,7 +12,7 @@ from numpy.typing import ArrayLike
 from .protocols import ID_KEY, Actuator, Optimizer
 from .utils import InferredReadable, Source
 
-_BLUESKY_UID_KEY: Literal["bluesky_uid"] = "bluesky_uid"
+_ACQUISITION_UID_KEY: Literal["acquisition_uid"] = "acquisition_uid"
 _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
 
 
@@ -47,7 +47,7 @@ def read_step(
     Parameters
     ----------
     uid : Hashable
-        The Bluesky run UID from the acquisition plan.
+        The acquisition identifier returned by the acquisition plan.
     suggestions : Sequence[Mapping]
         List of suggestion dictionaries, each containing an ID_KEY.
     outcomes : Sequence[Mapping]
@@ -108,12 +108,12 @@ def read_step(
         readable_cache[_SUGGESTION_IDS_KEY].update(sorted_sids)
     # Need to normalize the value here since `Hashable` is very broad
     normalized_uid = _acquisition_identifier_value(uid)
-    if _BLUESKY_UID_KEY not in readable_cache:
-        readable_cache[_BLUESKY_UID_KEY] = InferredReadable(
-            _BLUESKY_UID_KEY, source=Source.ACQUISITION_UID, initial_value=normalized_uid
+    if _ACQUISITION_UID_KEY not in readable_cache:
+        readable_cache[_ACQUISITION_UID_KEY] = InferredReadable(
+            _ACQUISITION_UID_KEY, source=Source.ACQUISITION_UID, initial_value=normalized_uid
         )
     else:
-        readable_cache[_BLUESKY_UID_KEY].update(normalized_uid)
+        readable_cache[_ACQUISITION_UID_KEY].update(normalized_uid)
     for name, value in suggestions_flat.items():
         if name not in readable_cache:
             readable_cache[name] = InferredReadable(name, source=Source.PARAMETER, initial_value=value)

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -1,7 +1,7 @@
 """Bluesky plan stubs for optimization."""
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from typing import Any, Literal
 
 import bluesky.plan_stubs as bps
@@ -17,7 +17,11 @@ _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
 
 @plan
 def read_step(
-    uid: str, suggestions: list[dict], outcomes: list[dict], n_points: int, readable_cache: dict[str, InferredReadable]
+    uid: Hashable,
+    suggestions: Sequence[Mapping],
+    outcomes: Sequence[Mapping],
+    n_points: int,
+    readable_cache: dict[str, InferredReadable],
 ) -> MsgGenerator[None]:
     """Plan stub to read the suggestions and outcomes of a single optimization step.
 
@@ -26,11 +30,11 @@ def read_step(
 
     Parameters
     ----------
-    uid : str
+    uid : Hashable
         The Bluesky run UID from the acquisition plan.
-    suggestions : list[dict]
+    suggestions : Sequence[Mapping]
         List of suggestion dictionaries, each containing an ID_KEY.
-    outcomes : list[dict]
+    outcomes : Sequence[Mapping]
         List of outcome dictionaries, each containing an ID_KEY matching suggestions.
     n_points : int
         Expected number of suggestions. Arrays will be padded to this length if needed.
@@ -41,11 +45,11 @@ def read_step(
     suggestion_by_id = {}
     outcome_by_id = {}
     for suggestion in suggestions:
-        suggestion_copy = suggestion.copy()
+        suggestion_copy = dict(suggestion)
         key = str(suggestion_copy.pop(ID_KEY))
         suggestion_by_id[key] = suggestion_copy
     for outcome in outcomes:
-        outcome_copy = outcome.copy()
+        outcome_copy = dict(outcome)
         key = str(outcome_copy.pop(ID_KEY))
         outcome_by_id[key] = outcome_copy
     sids = {str(sid) for sid in suggestion_by_id.keys()}

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -44,14 +44,17 @@ def read_step(
     If fewer suggestions are returned than n_points arrays are padded to n_points length
     with np.nan to ensure consistent shapes for event-model specification.
 
+    The emitted ``acquisition_uid`` field retains native array-like identifiers.
+    Other hashable identifiers are represented by ``repr(uid)``.
+
     Parameters
     ----------
     uid : Hashable
         The acquisition identifier returned by the acquisition plan.
     suggestions : Sequence[Mapping]
-        List of suggestion dictionaries, each containing an ID_KEY.
+        Sequence of suggestion mappings, each containing an ID_KEY.
     outcomes : Sequence[Mapping]
-        List of outcome dictionaries, each containing an ID_KEY matching suggestions.
+        Sequence of outcome mappings, each containing an ID_KEY matching suggestions.
     n_points : int
         Expected number of suggestions. Arrays will be padded to this length if needed.
     readable_cache : dict[str, InferredReadable]

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -1,7 +1,7 @@
 """Bluesky plan stubs for optimization."""
 
 from collections import defaultdict
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 from typing import Any, Literal
 
 import bluesky.plan_stubs as bps
@@ -21,7 +21,7 @@ def read_step(
     suggestions: Sequence[Mapping],
     outcomes: Sequence[Mapping],
     n_points: int,
-    readable_cache: dict[str, InferredReadable],
+    readable_cache: MutableMapping[str, InferredReadable],
 ) -> MsgGenerator[None]:
     """Plan stub to read the suggestions and outcomes of a single optimization step.
 
@@ -90,6 +90,8 @@ def read_step(
         )
     else:
         readable_cache[_SUGGESTION_IDS_KEY].update(sorted_sids)
+    # FIXME: Need to figure out how to handle Hashable type here, maybe only support
+    # for a stricter type? Hashable may be too broad here.
     if _BLUESKY_UID_KEY not in readable_cache:
         readable_cache[_BLUESKY_UID_KEY] = InferredReadable(
             _BLUESKY_UID_KEY, source=Source.ACQUISITION_UID, initial_value=uid

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -2,17 +2,33 @@
 
 from collections import defaultdict
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
 import numpy as np
 from bluesky.utils import MsgGenerator, plan
+from numpy.typing import ArrayLike
 
 from .protocols import ID_KEY, Actuator, Optimizer
 from .utils import InferredReadable, Source
 
 _BLUESKY_UID_KEY: Literal["bluesky_uid"] = "bluesky_uid"
 _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
+
+
+def _is_array_like_identifier(uid: Hashable) -> bool:
+    try:
+        numpy_array = np.array(uid)
+    except (TypeError, ValueError):
+        return False
+    return numpy_array.dtype != object
+
+
+def _acquisition_identifier_value(uid: Hashable) -> ArrayLike:
+    """Convert a hashable acquisition identifier to an event-readable value."""
+    if _is_array_like_identifier(uid):
+        return cast(ArrayLike, uid)
+    return repr(uid)
 
 
 @plan
@@ -90,14 +106,14 @@ def read_step(
         )
     else:
         readable_cache[_SUGGESTION_IDS_KEY].update(sorted_sids)
-    # FIXME: Need to figure out how to handle Hashable type here, maybe only support
-    # for a stricter type? Hashable may be too broad here.
+    # Need to normalize the value here since `Hashable` is very broad
+    normalized_uid = _acquisition_identifier_value(uid)
     if _BLUESKY_UID_KEY not in readable_cache:
         readable_cache[_BLUESKY_UID_KEY] = InferredReadable(
-            _BLUESKY_UID_KEY, source=Source.ACQUISITION_UID, initial_value=uid
+            _BLUESKY_UID_KEY, source=Source.ACQUISITION_UID, initial_value=normalized_uid
         )
     else:
-        readable_cache[_BLUESKY_UID_KEY].update(uid)
+        readable_cache[_BLUESKY_UID_KEY].update(normalized_uid)
     for name, value in suggestions_flat.items():
         if name not in readable_cache:
             readable_cache[name] = InferredReadable(name, source=Source.PARAMETER, initial_value=value)

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -58,7 +58,7 @@ def default_acquire(
     Parameters
     ----------
     suggestions: Sequence[Mapping]
-        A list of dictionaries, each containing the parameterization of a point to evaluate.
+        A sequence of mappings, each containing the parameterization of a point to evaluate.
         The "_id" key is optional and can be used to identify each suggestion. It is suggested
         to add "_id" values to the run metadata for later identification of the acquired data.
     actuators: Sequence[Actuator]
@@ -128,8 +128,8 @@ def optimize_step(
 
     Returns
     -------
-    tuple[str, Sequence[Mapping], Sequence[Mapping]]
-        A tuple containing the uid, suggestions, and outcomes of the step.
+    tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]
+        The acquisition identifier, suggestions, and outcomes of the step.
     """
     if optimization_problem.acquisition_plan is None:
         acquisition_plan = default_acquire
@@ -268,7 +268,7 @@ def sample_suggestions(
     Returns
     -------
     uid : Hashable
-        Bluesky run UID.
+        The acquisition identifier returned by the acquisition plan.
     suggestions : Sequence[Mapping]
         Suggestions with "_id" keys.
     outcomes : Sequence[Mapping]

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -1,7 +1,7 @@
 """Bluesky plans for optimization."""
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
@@ -29,7 +29,7 @@ SAMPLE_SUGGESTIONS_RUN_KEY: Literal["sample_suggestions"] = "sample_suggestions"
 OPTIMIZE_RUN_KEY: Literal["optimize"] = "optimize"
 
 
-def _unpack_for_list_scan(suggestions: list[dict], actuators: Sequence[Actuator]) -> list[Any]:
+def _unpack_for_list_scan(suggestions: Sequence[Mapping], actuators: Sequence[Actuator]) -> list[Any]:
     """Unpack the actuators and inputs into Bluesky list_scan plan arguments."""
     actuators_and_inputs = {actuator: [suggestion[actuator.name] for suggestion in suggestions] for actuator in actuators}
     unpacked_list = []
@@ -42,7 +42,7 @@ def _unpack_for_list_scan(suggestions: list[dict], actuators: Sequence[Actuator]
 
 @plan
 def default_acquire(
-    suggestions: list[dict],
+    suggestions: Sequence[Mapping],
     actuators: Sequence[Actuator],
     sensors: Sequence[Sensor] | None = None,
     *,
@@ -57,7 +57,7 @@ def default_acquire(
 
     Parameters
     ----------
-    suggestions: list[dict]
+    suggestions: Sequence[Mapping]
         A list of dictionaries, each containing the parameterization of a point to evaluate.
         The "_id" key is optional and can be used to identify each suggestion. It is suggested
         to add "_id" values to the run metadata for later identification of the acquired data.
@@ -115,7 +115,7 @@ def optimize_step(
     n_points: int = 1,
     *args: Any,
     **kwargs: Any,
-) -> MsgGenerator[tuple[str, list[dict], list[dict]]]:
+) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
     """
     Single step of the optimization loop.
 
@@ -128,7 +128,7 @@ def optimize_step(
 
     Returns
     -------
-    tuple[str, list[dict], list[dict]]
+    tuple[str, Sequence[Mapping], Sequence[Mapping]]
         A tuple containing the uid, suggestions, and outcomes of the step.
     """
     if optimization_problem.acquisition_plan is None:
@@ -239,10 +239,10 @@ def optimize(
 @plan
 def sample_suggestions(
     optimization_problem: OptimizationProblem,
-    suggestions: list[dict],
+    suggestions: Sequence[Mapping],
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
-) -> MsgGenerator[tuple[str, list[dict], list[dict]]]:
+) -> MsgGenerator[tuple[str, Sequence[Mapping], Sequence[Mapping]]]:
     """
     Evaluate specific parameter combinations.
 
@@ -254,7 +254,7 @@ def sample_suggestions(
     ----------
     optimization_problem : OptimizationProblem
         The optimization problem.
-    suggestions : list[dict]
+    suggestions : Sequence[Mapping]
         Parameter combinations to evaluate. Can be:
 
         - Optimizer suggestions (with "_id" keys from suggest())
@@ -269,9 +269,9 @@ def sample_suggestions(
     -------
     uid : str
         Bluesky run UID.
-    suggestions : list[dict]
+    suggestions : Sequence[Mapping]
         Suggestions with "_id" keys.
-    outcomes : list[dict]
+    outcomes : Sequence[Mapping]
         Evaluated outcomes.
 
     Raises
@@ -308,7 +308,7 @@ def sample_suggestions(
 
     @bpp.set_run_key_decorator(SAMPLE_SUGGESTIONS_RUN_KEY)
     @bpp.run_decorator(md=_md)
-    def _inner_sample_suggestions() -> MsgGenerator[tuple[str, list[dict], list[dict]]]:
+    def _inner_sample_suggestions() -> MsgGenerator[tuple[str, Sequence[Mapping], Sequence[Mapping]]]:
 
         # Acquire data, evaluate, and ingest outcomes
         if optimization_problem.acquisition_plan is None:

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -242,7 +242,7 @@ def sample_suggestions(
     suggestions: Sequence[Mapping],
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
-) -> MsgGenerator[tuple[str, Sequence[Mapping], Sequence[Mapping]]]:
+) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
     """
     Evaluate specific parameter combinations.
 
@@ -267,7 +267,7 @@ def sample_suggestions(
 
     Returns
     -------
-    uid : str
+    uid : Hashable
         Bluesky run UID.
     suggestions : Sequence[Mapping]
         Suggestions with "_id" keys.
@@ -308,7 +308,7 @@ def sample_suggestions(
 
     @bpp.set_run_key_decorator(SAMPLE_SUGGESTIONS_RUN_KEY)
     @bpp.run_decorator(md=_md)
-    def _inner_sample_suggestions() -> MsgGenerator[tuple[str, Sequence[Mapping], Sequence[Mapping]]]:
+    def _inner_sample_suggestions() -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
 
         # Acquire data, evaluate, and ingest outcomes
         if optimization_problem.acquisition_plan is None:
@@ -352,7 +352,7 @@ def seq_read(readables: Sequence[Readable], **kwargs: Any) -> MsgGenerator[dict[
 
 def acquire_baseline(
     optimization_problem: OptimizationProblem,
-    parameterization: dict[str, Any] | None = None,
+    parameterization: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator[None]:
     """
@@ -377,14 +377,15 @@ def acquire_baseline(
             raise ValueError(
                 "All actuators must also implement the Readable protocol to acquire a baseline from current positions."
             )
+    parameterization_copy = dict(parameterization)
     if ID_KEY not in parameterization:
-        parameterization[ID_KEY] = "baseline"
+        parameterization_copy[ID_KEY] = "baseline"
     optimizer = optimization_problem.optimizer
     if optimization_problem.acquisition_plan is None:
         acquisition_plan = default_acquire
     else:
         acquisition_plan = optimization_problem.acquisition_plan
-    uid = yield from acquisition_plan([parameterization], actuators, optimization_problem.sensors, **kwargs)
-    outcome = optimization_problem.evaluation_function(uid, [parameterization])[0]
-    data = {**outcome, **parameterization}
+    uid = yield from acquisition_plan([parameterization_copy], actuators, optimization_problem.sensors, **kwargs)
+    outcome = optimization_problem.evaluation_function(uid, [parameterization_copy])[0]
+    data = {**outcome, **parameterization_copy}
     optimizer.ingest([data])

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -1,6 +1,6 @@
 """Protocols that bridge between optimizer backends and Bluesky."""
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Literal, Protocol, TypeVar, runtime_checkable
 
@@ -43,7 +43,7 @@ class CanRegisterSuggestions(Protocol):
     that the suggestions are unique.
     """
 
-    def register_suggestions(self, suggestions: list[dict]) -> list[dict]:
+    def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """
         Register the suggestions with the optimizer.
 
@@ -69,13 +69,13 @@ class TrialFaultAware(Protocol):
     cleanup of processes not directly tied to the run engine
     """
 
-    def register_failures(self, suggestions: list[dict]) -> None:
+    def register_failures(self, suggestions: Sequence[Mapping]) -> None:
         """
         Register the failed suggestions with the optimizer.
 
         Parameters
         ----------
-        suggestions: list[dict]
+        suggestions: Sequence[Mapping]
             The suggestions to fail. Ids must be present.
         """
         ...
@@ -130,7 +130,7 @@ class Optimizer(Protocol):
     blop.ax.Agent : High-level interface that uses AxOptimizer internally.
     """
 
-    def suggest(self, num_points: int | None = None) -> list[dict]:
+    def suggest(self, num_points: int | None = None) -> Sequence[Mapping]:
         """
         Suggest a set of points in the input space, to be evaulated next.
 
@@ -144,13 +144,13 @@ class Optimizer(Protocol):
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries, each containing a parameterization of a point to evaluate next.
             Each dictionary must contain a unique "_id" key to identify each parameterization.
         """
         ...
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """
         Ingest a set of points into the experiment. Either from previously suggested points or from an external source.
 
@@ -159,12 +159,12 @@ class Optimizer(Protocol):
 
         Parameters
         ----------
-        points : list[dict]
+        points : Sequence[Mapping]
             A list of dictionaries, each containing the outcomes of each suggested parameterization.
         """
         ...
 
-    def get_best_points(self) -> list[tuple[Any, Mapping, Mapping]]:
+    def get_best_points(self) -> Sequence[tuple[Any, Mapping, Mapping]]:
         """
         Get a list of the optimal points found during optimization.
 
@@ -207,21 +207,21 @@ class EvaluationFunction(Protocol):
     :doc:`/tutorials/simple-experiment`
     """
 
-    def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
+    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """
-        Evaluate the data from a Bluesky run and produce outcomes.
+        Evaluate the acquired data and produce outcomes.
 
         Parameters
         ----------
-        uid: str
-            The unique identifier of the Bluesky run to evaluate.
-        suggestions: list[dict]
+        uid: Hashable
+            The unique identifier used to fetch acquired data to evaluate.
+        suggestions: Sequence[Mapping]
             A list of dictionaries, each containing the parameterization of a point to evaluate.
             The "_id" key is optional and can be used to identify each suggestion.
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries containing the outcomes of the run, one for each suggested parameterization.
             The "_id" key is optional and can be used to identify each outcome.
         """
@@ -246,27 +246,29 @@ class AcquisitionPlan(Protocol):
     Notes
     -----
     The acquisition plan is a Bluesky plan that should move the actuators to each
-    suggested position and acquire data from the sensors. It must return the UID
-    of the Bluesky run so that the evaluation function can retrieve the data.
+    suggested position and acquire data from the sensors. It is responsible for
+    returning an identifier that makes fetching the acquired data feasible.
     """
 
     @plan
     def __call__(
         self,
-        suggestions: list[dict],
+        suggestions: Sequence[Mapping],
         actuators: Sequence[Actuator],
         sensors: Sequence[Sensor] | None = None,
-        md: dict[str, Any] | None = None,
-    ) -> MsgGenerator[str]:
+        md: Mapping[Hashable, Any] | None = None,
+    ) -> MsgGenerator[Hashable]:
         """
         Acquire data for optimization.
 
         This should be a Bluesky plan that moves the actuators to each of their suggested positions
-        and acquires data from the sensors.
+        and acquires data from the sensors. Suggestions may be re-ordered for more efficient acquisition
+        but it is the responsibility of the implementer to ensure fetching the data during
+        evaluation is feasible.
 
         Parameters
         ----------
-        suggestions: list[dict]
+        suggestions: Sequence[Mapping]
             A list of dictionaries, each containing the parameterization of a point to evaluate.
             The "_id" key is optional and can be used to identify each suggestion. It is suggested
             to add "_id" values to the run metadata for later identification of the acquired data.
@@ -274,13 +276,13 @@ class AcquisitionPlan(Protocol):
             The actuators to move to their suggested positions.
         sensors: Sequence[Sensor], optional
             The sensors that produce data to evaluate.
-        md : dict[str, Any] | None, optional
+        md : Mapping[Hashable, Any] | None, optional
             Metadata to attach to the start document
 
         Returns
         -------
-        str
-            The unique identifier of the Bluesky run.
+        Hashable
+            The unique identifier used to fetch data for evaluation.
         """
         ...
 

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -49,13 +49,13 @@ class CanRegisterSuggestions(Protocol):
 
         Parameters
         ----------
-        suggestions: list[dict]
+        suggestions: Sequence[Mapping]
             The suggestions to register. The "_id" key is optional and will be overwritten if present.
 
         Returns
         -------
-        list[dict]
-            The original suggestions with an "_id" key added.
+        Sequence[Mapping]
+            The suggestions with an "_id" key added.
         """
         ...
 
@@ -145,8 +145,8 @@ class Optimizer(Protocol):
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries, each containing a parameterization of a point to evaluate next.
-            Each dictionary must contain a unique "_id" key to identify each parameterization.
+            A sequence of mappings, each containing a parameterization of a point to evaluate next.
+            Each mapping must contain a unique "_id" key to identify each parameterization.
         """
         ...
 
@@ -160,21 +160,21 @@ class Optimizer(Protocol):
         Parameters
         ----------
         points : Sequence[Mapping]
-            A list of dictionaries, each containing the outcomes of each suggested parameterization.
+            A sequence of mappings containing the outcomes of the evaluated parameterizations.
         """
         ...
 
     def get_best_points(self) -> Sequence[tuple[Any, Mapping, Mapping]]:
         """
-        Get a list of the optimal points found during optimization.
+        Get a sequence of the optimal points found during optimization.
 
         For single-objective optimization, returns a single best point.
         For multi-objective optimization, returns the Pareto-optimal set.
 
         Returns
         -------
-        list[tuple[Any, Mapping, Mapping]]
-            Each element in the list is a tuple of:
+        Sequence[tuple[Any, Mapping, Mapping]]
+            Each element is a tuple of:
               - "_id" of the suggestion
               - suggested parameters
               - measured outcomes
@@ -197,9 +197,9 @@ class EvaluationFunction(Protocol):
 
     Notes
     -----
-    The evaluation function is called after data acquisition to compute outcomes
-    from the acquired data. It should extract relevant data from the Bluesky run
-    and compute objective values and metrics for each suggestion.
+    The evaluation function is called after data acquisition to compute outcomes.
+    It uses the acquisition identifier returned by the acquisition plan to retrieve
+    the relevant data and computes objective values and metrics for each suggestion.
 
     Examples
     --------
@@ -214,15 +214,16 @@ class EvaluationFunction(Protocol):
         Parameters
         ----------
         uid: Hashable
-            The unique identifier used to fetch acquired data to evaluate.
+            The acquisition identifier returned by the acquisition plan. This may be a Bluesky run UID,
+            a tuple of event UIDs, or another hashable lookup key.
         suggestions: Sequence[Mapping]
-            A list of dictionaries, each containing the parameterization of a point to evaluate.
+            A sequence of mappings, each containing the parameterization of a point to evaluate.
             The "_id" key is optional and can be used to identify each suggestion.
 
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries containing the outcomes of the run, one for each suggested parameterization.
+            A sequence of mappings containing the outcomes of the acquisition, one for each suggested parameterization.
             The "_id" key is optional and can be used to identify each outcome.
         """
         ...
@@ -246,8 +247,8 @@ class AcquisitionPlan(Protocol):
     Notes
     -----
     The acquisition plan is a Bluesky plan that should move the actuators to each
-    suggested position and acquire data from the sensors. It is responsible for
-    returning an identifier that makes fetching the acquired data feasible.
+    suggested position, acquire data from the sensors, and return a hashable
+    identifier that the evaluation function can use to retrieve the acquired data.
     """
 
     @plan
@@ -269,7 +270,7 @@ class AcquisitionPlan(Protocol):
         Parameters
         ----------
         suggestions: Sequence[Mapping]
-            A list of dictionaries, each containing the parameterization of a point to evaluate.
+            A sequence of mappings, each containing the parameterization of a point to evaluate.
             The "_id" key is optional and can be used to identify each suggestion. It is suggested
             to add "_id" values to the run metadata for later identification of the acquired data.
         actuators: Sequence[Actuator]
@@ -282,7 +283,8 @@ class AcquisitionPlan(Protocol):
         Returns
         -------
         Hashable
-            The unique identifier used to fetch data for evaluation.
+            The identifier passed unchanged to the evaluation function. Examples include a Bluesky run UID
+            or a tuple of event UIDs.
         """
         ...
 
@@ -327,7 +329,7 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
     sensors: Sequence[Sensor]
         Objects that can produce data to acquire data from the beamline using the Bluesky RunEngine.
     evaluation_function: EvaluationFunction
-        A callable to evaluate data from a Bluesky run and produce outcomes.
+        A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
     acquisition_plan: AcquisitionPlan, optional
         A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
 
@@ -361,7 +363,7 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     sensors: Sequence[str]
         Names of objects that can produce data to acquire data from the beamline using the Bluesky RunEngine.
     evaluation_function: EvaluationFunction
-        A callable to evaluate data from a Bluesky run and produce outcomes.
+        A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
     acquisition_plan: str, optional
         The name of a Bluesky plan to acquire data. If not provided, a default plan name will be used.
         The plan must match the arguments of :class:`AcquisitionPlan`.

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -256,7 +256,7 @@ class AcquisitionPlan(Protocol):
         suggestions: Sequence[Mapping],
         actuators: Sequence[Actuator],
         sensors: Sequence[Sensor] | None = None,
-        md: Mapping[Hashable, Any] | None = None,
+        md: Mapping[str, Any] | None = None,
     ) -> MsgGenerator[Hashable]:
         """
         Acquire data for optimization.
@@ -276,7 +276,7 @@ class AcquisitionPlan(Protocol):
             The actuators to move to their suggested positions.
         sensors: Sequence[Sensor], optional
             The sensors that produce data to evaluate.
-        md : Mapping[Hashable, Any] | None, optional
+        md : Mapping[str, Any] | None, optional
             Metadata to attach to the start document
 
         Returns

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -14,7 +14,7 @@ a queueserver, rather than directly through a RunEngine.
 import logging
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -213,7 +213,7 @@ class _OptimizationState:
     num_points: int = 1
     checkpoint_interval: int | None = None
     current_iteration: int = 0
-    current_suggestions: list[dict] = field(default_factory=list)
+    current_suggestions: Sequence[Mapping] = field(default_factory=list)
     current_uid: str | None = None
     uids: list[str] = field(default_factory=list)
 
@@ -337,7 +337,7 @@ class QueueserverOptimizationRunner:
             raise
         return future
 
-    def submit_suggestions(self, suggestions: list[dict]) -> Future[OptimizationResult]:
+    def submit_suggestions(self, suggestions: Sequence[Mapping]) -> Future[OptimizationResult]:
         """
         Manually submit suggestions to the queue.
 
@@ -345,7 +345,7 @@ class QueueserverOptimizationRunner:
 
         Parameters
         ----------
-        suggestions : list[dict]
+        suggestions : Sequence[Mapping]
             Parameter combinations to evaluate. Can be:
 
             - Optimizer suggestions (with "_id" keys from suggest())
@@ -415,7 +415,7 @@ class QueueserverOptimizationRunner:
         if self._current_future is not None and not self._current_future.done():
             self._current_future.set_exception(exc)
 
-    def _try_register_failures(self, suggestions: list[dict]) -> None:
+    def _try_register_failures(self, suggestions: Sequence[Mapping]) -> None:
         """Notify a TrialFaultAware optimizer of failed suggestions, if supported."""
         if suggestions and isinstance(self._problem.optimizer, TrialFaultAware):
             try:
@@ -430,7 +430,7 @@ class QueueserverOptimizationRunner:
             raise RuntimeError("Optimization loop is already running.")
         self._client.check_environment()
 
-    def _build_plan(self, suggestions: list[dict]) -> BPlan:
+    def _build_plan(self, suggestions: Sequence[Mapping]) -> BPlan:
         """LOCKED: Build the plan to submit and update current state."""
         if self._state is None:
             raise RuntimeError("_build_plan() called before run() or submit_suggestions()")

--- a/src/blop/scipy/inverter.py
+++ b/src/blop/scipy/inverter.py
@@ -137,8 +137,8 @@ class InteractiveOptimizer(Optimizer):
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries, each containing a parameterization of a point to evaluate next.
-            Each dictionary must contain a unique "_id" key to identify each parameterization.
+            A sequence of mappings, each containing a parameterization of a point to evaluate next.
+            Each mapping must contain a unique "_id" key to identify each parameterization.
         """
         try:
             self.final = self.thread_monitor.result(timeout=0.01)
@@ -173,7 +173,7 @@ class InteractiveOptimizer(Optimizer):
         Parameters
         ----------
         points : Sequence[Mapping]
-            A list of dictionaries, each containing the outcomes of each suggested parameterization.
+            A sequence of mappings containing the outcomes of each suggested parameterization.
         """
         for res in points:
             y = res[self._objective.name]

--- a/src/blop/scipy/inverter.py
+++ b/src/blop/scipy/inverter.py
@@ -1,7 +1,7 @@
 """Core Scipy optimizer porting scipy algorithms."""
 
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Event, Thread
@@ -122,7 +122,7 @@ class InteractiveOptimizer(Optimizer):
         """Lifetime threads when using with."""
         self.close()
 
-    def suggest(self, num_points: int | None = None) -> list[dict]:
+    def suggest(self, num_points: int | None = None) -> Sequence[Mapping]:
         """
         Provide a set of points in the input space, to be evaulated next.
 
@@ -136,7 +136,7 @@ class InteractiveOptimizer(Optimizer):
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries, each containing a parameterization of a point to evaluate next.
             Each dictionary must contain a unique "_id" key to identify each parameterization.
         """
@@ -164,7 +164,7 @@ class InteractiveOptimizer(Optimizer):
             suggestions.append(suggestion)
         return suggestions
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """
         Ingest a set of points into the experiment. Either from previously suggested points or from an external source.
 
@@ -172,7 +172,7 @@ class InteractiveOptimizer(Optimizer):
 
         Parameters
         ----------
-        points : list[dict]
+        points : Sequence[Mapping]
             A list of dictionaries, each containing the outcomes of each suggested parameterization.
         """
         for res in points:

--- a/src/blop/scipy/scipy.py
+++ b/src/blop/scipy/scipy.py
@@ -225,8 +225,8 @@ class Scipy:
         Returns
         -------
         Sequence[Mapping]
-            A list of dictionaries, each containing a parameterization of a point to
-            evaluate next. Each dictionary includes an "_id" key for identification.
+            A sequence of mappings, each containing a parameterization of a point to
+            evaluate next. Each mapping includes an "_id" key for identification.
         """
         return self.optimizer.suggest(num_points)
 
@@ -240,9 +240,9 @@ class Scipy:
         Parameters
         ----------
         points : Sequence[Mapping]
-            A list of dictionaries, each containing outcomes for a trial. For suggested
-            points, include the "_id" key. For external data, include DOF names and
-            objective values, and omit "_id".
+            A sequence of mappings containing outcomes for a trial. For suggested points,
+            include the "_id" key. For external data, include DOF names and objective
+            values, and omit "_id".
 
         Notes
         -----

--- a/src/blop/scipy/scipy.py
+++ b/src/blop/scipy/scipy.py
@@ -208,7 +208,7 @@ class Scipy:
             acquisition_plan=self._acquisition_plan,
         )
 
-    def suggest(self, num_points: int = 1) -> list[dict]:
+    def suggest(self, num_points: int = 1) -> Sequence[Mapping]:
         """
         Get the next point(s) to evaluate in the search space.
 
@@ -224,13 +224,13 @@ class Scipy:
 
         Returns
         -------
-        list[dict]
+        Sequence[Mapping]
             A list of dictionaries, each containing a parameterization of a point to
             evaluate next. Each dictionary includes an "_id" key for identification.
         """
         return self.optimizer.suggest(num_points)
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """
         Ingest evaluation results into the optimizer.
 
@@ -239,7 +239,7 @@ class Scipy:
 
         Parameters
         ----------
-        points : list[dict]
+        points : Sequence[Mapping]
             A list of dictionaries, each containing outcomes for a trial. For suggested
             points, include the "_id" key. For external data, include DOF names and
             objective values, and omit "_id".

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -99,12 +99,12 @@ def test_optimize(RE):
     assert len(events) == 1
     data = events[0]["data"]
     assert "suggestion_ids" in data
-    assert "bluesky_uid" in data
+    assert "acquisition_uid" in data
     assert "x1" in data
     assert "objective" in data
     assert data["x1"] == 0.0
     assert data["objective"] == 0.0
-    assert data["bluesky_uid"] and isinstance(data["bluesky_uid"], str)
+    assert data["acquisition_uid"] and isinstance(data["acquisition_uid"], str)
 
 
 def test_optimization_failure(RE):
@@ -165,7 +165,7 @@ def test_optimize_multiple(RE):
     for event in events:
         data = event["data"]
         assert "suggestion_ids" in data
-        assert "bluesky_uid" in data
+        assert "acquisition_uid" in data
         assert "x1" in data
         assert "objective" in data
         assert data["x1"] == 0.0
@@ -201,7 +201,7 @@ def test_optimize_multiple_with_n_points(RE):
     for event in events:
         data = event["data"]
         assert "suggestion_ids" in data
-        assert "bluesky_uid" in data
+        assert "acquisition_uid" in data
         assert "x1" in data
         assert "objective" in data
         sid = data["suggestion_ids"]
@@ -268,7 +268,7 @@ def test_optimize_complex_case(RE):
     for event in events:
         data = event["data"]
         assert "suggestion_ids" in data
-        assert "bluesky_uid" in data
+        assert "acquisition_uid" in data
         assert "x1" in data
         assert "x2" in data
         assert "x3" in data
@@ -280,7 +280,7 @@ def test_optimize_complex_case(RE):
         assert _to_list(data["objective1"]) == [0.0, 0.1]
         assert _to_list(data["objective2"]) == [0.1, 0.2]
         assert _to_list(data["suggestion_ids"]) == ["0", "1"]
-        assert data["bluesky_uid"] in uids
+        assert data["acquisition_uid"] in uids
 
 
 @pytest.mark.parametrize("checkpoint_interval", [0, 1, 2, 3])
@@ -360,12 +360,12 @@ def test_optimize_event_document_structure(RE):
 
     # Validate required fields from _read_step
     assert "suggestion_ids" in data
-    assert "bluesky_uid" in data
+    assert "acquisition_uid" in data
     assert "x1" in data
     assert "objective" in data
 
     # Validate predictable values from custom acquisition plan
-    assert data["bluesky_uid"] == "test-uid-123"
+    assert data["acquisition_uid"] == "test-uid-123"
     assert data["x1"] == 0.5
     assert data["objective"] == 1.25
     assert data["suggestion_ids"] == "0"
@@ -396,7 +396,7 @@ def test_optimize_with_tuple_acquisition_identifier(RE):
     acquisition_identifier = ("event-a", "event-b")
     evaluation_function.assert_called_once_with(acquisition_identifier, [suggestion])
     assert len(events) == 1
-    assert events[0]["data"]["bluesky_uid"] == acquisition_identifier
+    assert events[0]["data"]["acquisition_uid"] == acquisition_identifier
 
 
 def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
@@ -423,7 +423,7 @@ def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
 
     evaluation_function.assert_called_once_with(_CUSTOM_ACQUISITION_IDENTIFIER, [suggestion])
     assert len(events) == 1
-    assert events[0]["data"]["bluesky_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
+    assert events[0]["data"]["acquisition_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
 
 
 def test_optimize_step_custom_acquisition_plan(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -25,6 +25,31 @@ def _test_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
     return "test-uid-123"
 
 
+@plan
+def _tuple_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns a tuple acquisition identifier."""
+    yield from bps.null()
+    return ("event-a", "event-b")
+
+
+class _CustomAcquisitionIdentifier:
+    def __hash__(self):
+        return 1
+
+    def __repr__(self):
+        return "CustomAcquisitionIdentifier()"
+
+
+_CUSTOM_ACQUISITION_IDENTIFIER = _CustomAcquisitionIdentifier()
+
+
+@plan
+def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns a custom hashable acquisition identifier."""
+    yield from bps.null()
+    return _CUSTOM_ACQUISITION_IDENTIFIER
+
+
 def _collect_optimize_events():
     """Return a callback and list that collect event docs from the outer optimize run."""
     events = []
@@ -344,6 +369,61 @@ def test_optimize_event_document_structure(RE):
     assert data["x1"] == 0.5
     assert data["objective"] == 1.25
     assert data["suggestion_ids"] == "0"
+
+
+def test_optimize_with_tuple_acquisition_identifier(RE):
+    """Pass tuple acquisition identifiers unchanged to evaluation and event data."""
+    suggestion = {"x1": 0.5, "_id": 0}
+    outcome = {"objective": 1.25, "_id": 0}
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [suggestion]
+    evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[outcome])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_tuple_acquisition_plan,
+    )
+
+    callback, events = _collect_optimize_events()
+    RE.subscribe(callback)
+    try:
+        RE(optimize(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    acquisition_identifier = ("event-a", "event-b")
+    evaluation_function.assert_called_once_with(acquisition_identifier, [suggestion])
+    assert len(events) == 1
+    assert events[0]["data"]["bluesky_uid"] == acquisition_identifier
+
+
+def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
+    """Store repr for hashable acquisition identifiers that are not native array-like values."""
+    suggestion = {"x1": 0.5, "_id": 0}
+    outcome = {"objective": 1.25, "_id": 0}
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [suggestion]
+    evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[outcome])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_custom_identifier_acquisition_plan,
+    )
+
+    callback, events = _collect_optimize_events()
+    RE.subscribe(callback)
+    try:
+        RE(optimize(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    evaluation_function.assert_called_once_with(_CUSTOM_ACQUISITION_IDENTIFIER, [suggestion])
+    assert len(events) == 1
+    assert events[0]["data"]["bluesky_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
 
 
 def test_optimize_step_custom_acquisition_plan(RE):

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -1,7 +1,7 @@
 """A set of useful helper utilities."""
 
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any
 
@@ -156,7 +156,7 @@ def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = Non
     return index
 
 
-def route_suggestions(suggestions: list[dict], starting_position: dict | None = None):
+def route_suggestions(suggestions: Sequence[Mapping], starting_position: dict | None = None):
     """Route suggestions using networkx TSP solver."""
     if len(suggestions) == 1:
         return suggestions

--- a/src/blop/xopt/optimizer.py
+++ b/src/blop/xopt/optimizer.py
@@ -128,7 +128,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
     def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Register external suggestions with the optimizer."""
         # Attach stable blop trial IDs and cache suggested parameterizations by ID.
-        registered: Sequence[Mapping] = []
+        registered: list[dict] = []
         for suggestion in suggestions:
             trial_id = self._next_id
             self._next_id += 1

--- a/src/blop/xopt/optimizer.py
+++ b/src/blop/xopt/optimizer.py
@@ -1,7 +1,7 @@
 """Optimizer implementation using Xopt as the optimization backend."""
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from importlib import import_module
 from pathlib import Path
 from typing import Any
@@ -109,7 +109,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
         data = self._generator.data
         return isinstance(data, pd.DataFrame) and not data.empty
 
-    def suggest(self, num_points: int | None = None) -> list[dict]:
+    def suggest(self, num_points: int | None = None) -> Sequence[Mapping]:
         """Suggested points to sample from the optimizer."""
         # Default to single-point suggestion when caller does not specify cardinality.
         if num_points is None:
@@ -125,10 +125,10 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
             suggestions = self._generator.suggest(num_points)
         return self.register_suggestions(suggestions)
 
-    def register_suggestions(self, suggestions: list[dict]) -> list[dict]:
+    def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Register external suggestions with the optimizer."""
         # Attach stable blop trial IDs and cache suggested parameterizations by ID.
-        registered: list[dict] = []
+        registered: Sequence[Mapping] = []
         for suggestion in suggestions:
             trial_id = self._next_id
             self._next_id += 1
@@ -142,7 +142,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
 
         return registered
 
-    def ingest(self, points: list[dict]) -> None:
+    def ingest(self, points: Sequence[Mapping]) -> None:
         """Ingest outcomes into the optimizer."""
         if not points:
             return
@@ -198,7 +198,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
         if rows_to_append:
             self._generator.ingest(rows_to_append)
 
-    def register_failures(self, suggestions: list[dict]) -> None:
+    def register_failures(self, suggestions: Sequence[Mapping]) -> None:
         """Register failures with the optimizer."""
         # Remove failed suggestions from pending parameter cache.
         for suggestion in suggestions:
@@ -206,7 +206,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
             if trial_id is not None:
                 self._params_by_id.pop(trial_id, None)
 
-    def get_best_points(self) -> list[tuple[int | str, Mapping, Mapping]]:
+    def get_best_points(self) -> Sequence[tuple[int | str, Mapping, Mapping]]:
         """Best points from the optimizer."""
         # Return no points when no data has been ingested.
         if not self._generator_has_data():


### PR DESCRIPTION
# Summary

Relaxes the typing of core `blop.protocols` to accept Python `collections.abc` types.

# Motivation

Protocols should use general types in their method signatures rather than concrete Python types. This allows for greater flexibility in the protocol and less type conversion necessary for the user to deal with when implementing custom optimizers, evaluation functions, and acquisition plans.

One additional benefit is that these more generic types are immutable. E.g. `list` is mutable, but `Sequence` is not. Same with `dict` versus `Mapping`. Immutability is important to preserve and now the type checker can help us from making mistakes like this.

# Key Decisions

- `list[dict]` becomes `Sequence[Mapping]` (no change in default behavior)
- `uid: str` in `EvaluationFunction` becomes `uid: Hashable` (no change in default behavior, but added flexibility things such as `tuple[str, ...]` or custom hashable objects.
  - This change had downstream impacts on how we store this data in event-model through `InferredReadable`. I try to store the native type, unless it is a custom hashable object, where we store `repr(uid)` instead.
  - Makes development of #336 much easier since we can reference a tuple of event UIDs or something similar as the default acquisition behavior.
  - Generally gives greater flexibility for writing custom `AcquisitionPlan`s and `EvaluationFunction`s and fetching acquired data from storage.

# Breaking Changes

Users of Blop should not see any immediate breaking changes since we are merely relaxing type constraints. However, they may notice two things:
- Type checkers like `pyright` will fail if users write custom `AcquisitionPlan`s or `EvaluationFunction`s using the old types in the signature. This does not impact runtime behavior.
- Change from `"bluesky_uid"` as the data key for `optimization` run/stream event documents to `"acquisition_uid"` since the return type of `AcquisitionPlan` is now any `Hashable` object. It is no longer always a Bluesky run UID. 