### PR TITLE
Optimization within a single Bluesky run

### DIFF
--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -26,8 +26,10 @@ chosen storage or event system (typically stashing the suggestions in proper
 order in storage or tagging the run markdown).
 
 The plan must return a hashable acquisition identifier. Blop passes that value
-unchanged to the evaluation function. A Bluesky run UID is the usual identifier,
-but a tuple of event UIDs can identify acquisitions performed within one run.
+unchanged to the evaluation function. A Bluesky run UID is the usual identifier
+for run-owning acquisitions. The in-run default returns suggestion IDs in the
+order they were executed, but custom plans may return any hashable key their
+matching evaluation function understands.
 
 A simple example that optimizes in a subspace while executing measurements in
 the full physical coordinate system is shown below. 

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -12,7 +12,7 @@ commonly used at beamlines while also supporting data acquired within a single B
 Anatomy of an Evaluation Function
 ---------------------------------
 
-An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
+An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The identifier may be a Bluesky run UID, suggestion IDs in executed order, a tuple of event UIDs, or another hashable key understood by the evaluator. The suggestion sequence is optimizer-provided and is not guaranteed to be in acquisition order; match data and outcomes by ``_id``.
 
 A typical implementation is shown below:
 
@@ -40,7 +40,7 @@ A typical implementation is shown below:
             # Typical responsibilities include:
             #   - Retrieving the data associated with the identifier
             #   - Iterating over individual suggestions in the acquisition
-            #       - found in a run's start document under "blop_suggestions" when using default_acquire
+            #       - using the acquisition plan's documented order/correlation key
             #   - Constructing a per-suggestion analysis context
             #   - Calling a lower-level objective function for each sample or suggestion
 

--- a/docs/source/explanations/protocols.rst
+++ b/docs/source/explanations/protocols.rst
@@ -46,4 +46,4 @@ This protocol design allows you to pick and choose only the components you care 
 
 Blop provides built-in optimizers for common beamline optimization use cases, such as Bayesian optimization with `Ax <https://ax.dev>`_.
 
-Similarly, Blop provides :func:`blop.plans.default_acquire` for run-owning acquisitions and :func:`blop.plans.default_in_run_acquire` for acquisition inside one optimization run.
+Similarly, Blop provides :func:`blop.plans.default_acquire` for run-owning acquisitions and :func:`blop.plan_stubs.list_scan_in_run` for acquisition inside one optimization run.

--- a/docs/source/explanations/protocols.rst
+++ b/docs/source/explanations/protocols.rst
@@ -20,9 +20,9 @@ Data Flow
 
 The data flow for a typical optimization workflow is as follows:
 
-1. The optimizer suggests a sequence of mappings describing points to evaluate.
+1. The optimizer suggests a sequence of mappings describing points to evaluate. When suggestions include ``_id`` values used by Blop optimization plans, those values must be unique within a batch and hashable.
 2. The acquisition plan acquires data and returns a hashable acquisition identifier.
-3. Blop passes that identifier unchanged to the evaluation function, which transforms the acquired data into a sequence of outcome mappings.
+3. Blop passes that identifier unchanged to the evaluation function, which transforms the acquired data into a sequence of outcome mappings. The suggestion sequence passed to the evaluator is optimizer-provided, not necessarily acquisition-ordered.
 4. The optimizer ingests the outcomes to inform future suggestions.
 
 .. image:: ../_static/protocol-data-flow.png
@@ -46,4 +46,4 @@ This protocol design allows you to pick and choose only the components you care 
 
 Blop provides built-in optimizers for common beamline optimization use cases, such as Bayesian optimization with `Ax <https://ax.dev>`_.
 
-Similarly, Blop provides a :func:`blop.plans.default_acquire` acquisition plan that is compatible with most beamline optimization use cases.
+Similarly, Blop provides :func:`blop.plans.default_acquire` for run-owning acquisitions and :func:`blop.plans.default_in_run_acquire` for acquisition inside one optimization run.

--- a/docs/source/reference/plan_stubs.rst
+++ b/docs/source/reference/plan_stubs.rst
@@ -1,6 +1,8 @@
 Plan Stubs
 ==========
 
+.. autofunction:: blop.plan_stubs.list_scan_in_run
+
 .. autofunction:: blop.plan_stubs.navigate_to_best
 
 .. autofunction:: blop.plan_stubs.read_step

--- a/docs/source/reference/plans.rst
+++ b/docs/source/reference/plans.rst
@@ -3,9 +3,13 @@ Plans
 
 .. autofunction:: blop.plans.optimize
 
+.. autofunction:: blop.plans.optimize_in_run
+
 .. autofunction:: blop.plans.optimize_step
 
 .. autofunction:: blop.plans.default_acquire
+
+.. autofunction:: blop.plans.default_in_run_acquire
 
 .. autofunction:: blop.plans.acquire_baseline
 

--- a/docs/source/reference/plans.rst
+++ b/docs/source/reference/plans.rst
@@ -9,8 +9,6 @@ Plans
 
 .. autofunction:: blop.plans.default_acquire
 
-.. autofunction:: blop.plans.default_in_run_acquire
-
 .. autofunction:: blop.plans.acquire_baseline
 
 .. autofunction:: blop.plans.sample_suggestions

--- a/src/blop/__init__.py
+++ b/src/blop/__init__.py
@@ -1,9 +1,9 @@
 """A bridge between optimization algorithms and Bluesky."""
 
+from .plan_stubs import list_scan_in_run
 from .plans import (
     acquire_baseline,
     default_acquire,
-    default_in_run_acquire,
     optimize,
     optimize_in_run,
     optimize_step,
@@ -19,7 +19,7 @@ __all__ = [
     "__version__",
     "acquire_baseline",
     "default_acquire",
-    "default_in_run_acquire",
+    "list_scan_in_run",
     "optimize",
     "optimize_in_run",
     "optimize_step",

--- a/src/blop/__init__.py
+++ b/src/blop/__init__.py
@@ -1,6 +1,14 @@
 """A bridge between optimization algorithms and Bluesky."""
 
-from .plans import acquire_baseline, default_acquire, optimize, optimize_in_run, optimize_step, sample_suggestions
+from .plans import (
+    acquire_baseline,
+    default_acquire,
+    default_in_run_acquire,
+    optimize,
+    optimize_in_run,
+    optimize_step,
+    sample_suggestions,
+)
 
 try:
     from ._version import __version__
@@ -11,6 +19,7 @@ __all__ = [
     "__version__",
     "acquire_baseline",
     "default_acquire",
+    "default_in_run_acquire",
     "optimize",
     "optimize_in_run",
     "optimize_step",

--- a/src/blop/__init__.py
+++ b/src/blop/__init__.py
@@ -1,6 +1,6 @@
 """A bridge between optimization algorithms and Bluesky."""
 
-from .plans import acquire_baseline, default_acquire, optimize, optimize_step, sample_suggestions
+from .plans import acquire_baseline, default_acquire, optimize, optimize_in_run, optimize_step, sample_suggestions
 
 try:
     from ._version import __version__
@@ -12,6 +12,7 @@ __all__ = [
     "acquire_baseline",
     "default_acquire",
     "optimize",
+    "optimize_in_run",
     "optimize_step",
     "sample_suggestions",
 ]

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -38,6 +38,7 @@ def read_step(
     outcomes: Sequence[Mapping],
     n_points: int,
     readable_cache: MutableMapping[str, InferredReadable],
+    stream_name: str = "primary",
 ) -> MsgGenerator[None]:
     """Plan stub to read the suggestions and outcomes of a single optimization step.
 
@@ -59,6 +60,8 @@ def read_step(
         Expected number of suggestions. Arrays will be padded to this length if needed.
     readable_cache : dict[str, InferredReadable]
         Cache of InferredReadable objects to reuse across iterations.
+    stream_name : str, optional
+        Event stream name for the optimization tracking event.
     """
     # Group by ID_KEY to get proper suggestion/outcome order
     suggestion_by_id = {}
@@ -129,7 +132,7 @@ def read_step(
             readable_cache[name].update(value)
 
     # Read and save to produce a single event
-    yield from bps.trigger_and_read(list(readable_cache.values()))
+    yield from bps.trigger_and_read(list(readable_cache.values()), name=stream_name)
 
 
 @plan

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -1,16 +1,29 @@
 """Bluesky plan stubs for optimization."""
 
+import logging
 from collections import defaultdict
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
+import bluesky.plans as bp
 import numpy as np
+from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
 from numpy.typing import ArrayLike
 
-from .protocols import ID_KEY, Actuator, Optimizer
-from .utils import InferredReadable, Source
+from .protocols import ID_KEY, Actuator, Optimizer, Sensor
+from .utils import (
+    InferredReadable,
+    Source,
+    _drop_run_control_messages,
+    _suggestion_ids,
+    _unpack_for_list_scan,
+    _validate_suggestions,
+    route_suggestions,
+)
+
+logger = logging.getLogger(__name__)
 
 _ACQUISITION_UID_KEY: Literal["acquisition_uid"] = "acquisition_uid"
 _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
@@ -29,6 +42,27 @@ def _acquisition_identifier_value(uid: Hashable) -> ArrayLike:
     if _is_array_like_identifier(uid):
         return cast(ArrayLike, uid)
     return repr(uid)
+
+
+@plan
+def seq_read(readables: Sequence[Readable], **kwargs: Any) -> MsgGenerator[dict[str, Any]]:
+    """
+    Read the current values of the given readables.
+
+    Parameters
+    ----------
+    readables : Sequence[Readable]
+        The readables to read.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary of the readable names and their current values.
+    """
+    results = {}
+    for readable in readables:
+        results[readable.name] = yield from bps.rd(readable, **kwargs)
+    return results
 
 
 @plan
@@ -188,3 +222,75 @@ def navigate_to_best(
 
     if moves:
         yield from bps.mv(*moves)
+
+
+@plan
+def list_scan_in_run(
+    suggestions: Sequence[Mapping],
+    actuators: Sequence[Actuator],
+    sensors: Sequence[Sensor] | None = None,
+    *,
+    per_step: bp.PerStep | None = None,
+    **kwargs: Any,
+) -> MsgGenerator[tuple[Hashable, ...]]:
+    """Acquire suggestions inside an already-open Bluesky run.
+
+    This plan moves through the suggestions, optionally reordering them for efficient motion,
+    and executes a Bluesky list scan without opening a child run. The list scan's stage and
+    unstage messages are preserved.
+
+    Parameters
+    ----------
+    suggestions : Sequence[Mapping]
+        Suggested parameterizations to execute. Each suggestion must contain a hashable ``_id``.
+    actuators : Sequence[Actuator]
+        Actuators to move to the suggested positions.
+    sensors : Sequence[Sensor] | None, optional
+        Sensors that produce data to evaluate. Non-readable sensors are ignored.
+    per_step : bp.PerStep | None, optional
+        Bluesky list-scan step hook. Custom hooks may emit any number of events into any streams.
+    **kwargs : Any
+        Additional keyword arguments to pass to :func:`bluesky.plans.list_scan`.
+
+    Returns
+    -------
+    tuple[Hashable, ...]
+        Suggestion IDs in the order the suggestions were executed.
+
+        This identifier intentionally does not encode stream names, event UIDs, event counts, or
+        per-stream offsets. Custom ``per_step`` hooks may emit any number of events into any number
+        of streams. The matching evaluation function is responsible for interpreting those documents
+        and correlating them with these ordered suggestion IDs.
+
+    Yields
+    ------
+    Msg
+        Bluesky messages.
+    """
+    _validate_suggestions(suggestions)
+    if sensors is None:
+        sensors = []
+    readables = [s for s in sensors if isinstance(s, Readable)]
+    if len(readables) != len(sensors):
+        logger.warning(f"Some sensors are not readable and will be ignored. Using only the readable sensors: {readables}")
+
+    if len(suggestions) > 1:
+        if all(isinstance(actuator, Readable) for actuator in actuators):
+            current_position = yield from seq_read(cast(Sequence[Readable], actuators))
+        else:
+            current_position = None
+        suggestions = route_suggestions(suggestions, starting_position=current_position)
+
+    suggestion_ids = _suggestion_ids(suggestions)
+    plan_args = _unpack_for_list_scan(suggestions, actuators)
+    # TODO: fix argument type in bluesky.plans.list_scan
+    yield from _drop_run_control_messages(
+        bp.list_scan(
+            readables,
+            *plan_args,  # type: ignore[arg-type]
+            per_step=per_step,
+            **kwargs,
+        )
+    )
+
+    return suggestion_ids

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -239,6 +239,11 @@ def list_scan_in_run(
     and executes a Bluesky list scan without opening a child run. The list scan's stage and
     unstage messages are preserved.
 
+    .. warning::
+
+        The single-run optimization API is **experimental**. This plan may change in
+        future releases without a deprecation period.
+
     Parameters
     ----------
     suggestions : Sequence[Mapping]

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -85,7 +85,6 @@ def default_acquire(
     if len(readables) != len(sensors):
         logger.warning(f"Some sensors are not readable and will be ignored. Using only the readable sensors: {readables}")
 
-    print(f"IN default_acquire before re-ordering: {suggestions}")
     if len(suggestions) > 1:
         if all(isinstance(actuator, Readable) for actuator in actuators):
             current_position = yield from seq_read(cast(Sequence[Readable], actuators))
@@ -93,7 +92,6 @@ def default_acquire(
             current_position = None
         suggestions = route_suggestions(suggestions, starting_position=current_position)
 
-    print(f"IN default_acquire after re-ordering: {suggestions}")
     md = {"blop_suggestions": suggestions, "run_key": _DEFAULT_ACQUIRE_RUN_KEY}
     plan_args = _unpack_for_list_scan(suggestions, actuators)
     return (

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -7,15 +7,21 @@ from typing import Any, Literal, cast
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
+from bluesky.callbacks import CallbackBase
 from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
+from event_model import Event
 
 from .plan_stubs import read_step
 from .protocols import (
     ID_KEY,
     Actuator,
     CanRegisterSuggestions,
+    EvaluationFunction,
+    InRunDataReference,
+    InRunEvaluationFunction,
     OptimizationProblem,
+    Optimizer,
     Sensor,
     SupportsStoppingCriteria,
     TrialFaultAware,
@@ -27,6 +33,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ACQUIRE_RUN_KEY: Literal["default_acquire"] = "default_acquire"
 SAMPLE_SUGGESTIONS_RUN_KEY: Literal["sample_suggestions"] = "sample_suggestions"
 OPTIMIZE_RUN_KEY: Literal["optimize"] = "optimize"
+OPTIMIZE_IN_RUN_KEY: Literal["optimize_in_run"] = "optimize_in_run"
+OPTIMIZE_IN_RUN_TRACKING_STREAM: Literal["optimization"] = "optimization"
 
 
 def _unpack_for_list_scan(suggestions: Sequence[Mapping], actuators: Sequence[Actuator]) -> list[Any]:
@@ -109,6 +117,24 @@ def default_acquire(
     )
 
 
+def _validate_suggestions_have_ids(suggestions: list[dict]) -> None:
+    """Ensure every suggestion can be matched to an evaluated outcome."""
+    if any(ID_KEY not in suggestion for suggestion in suggestions):
+        raise ValueError(
+            f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes. Please review your "
+            f"optimizer implementation. Got suggestions: {suggestions}"
+        )
+
+
+def _validate_outcomes_have_ids(outcomes: list[dict], suggestions: list[dict]) -> None:
+    """Ensure every outcome can be matched to an optimizer suggestion."""
+    if any(ID_KEY not in outcome for outcome in outcomes):
+        raise ValueError(
+            f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "
+            f"evaluation function. Got suggestions: {suggestions} and outcomes: {outcomes}"
+        )
+
+
 @plan
 def optimize_step(
     optimization_problem: OptimizationProblem,
@@ -138,11 +164,7 @@ def optimize_step(
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
     suggestions = optimizer.suggest(n_points)
-    if any(ID_KEY not in suggestion for suggestion in suggestions):
-        raise ValueError(
-            f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes. Please review your "
-            f"optimizer implementation. Got suggestions: {suggestions}"
-        )
+    _validate_suggestions_have_ids(suggestions)
     try:
         uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, *args, **kwargs)
     except Exception:
@@ -150,15 +172,148 @@ def optimize_step(
             optimizer.register_failures(suggestions)
         raise
 
-    outcomes = optimization_problem.evaluation_function(uid, suggestions)
-    if any(ID_KEY not in outcome for outcome in outcomes):
-        raise ValueError(
-            f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "
-            f"evaluation function. Got suggestions: {suggestions} and outcomes: {outcomes}"
-        )
+    evaluation_function: EvaluationFunction = optimization_problem.evaluation_function
+    outcomes = evaluation_function(uid, suggestions)
+    _validate_outcomes_have_ids(outcomes, suggestions)
     optimizer.ingest(outcomes)
 
     return uid, suggestions, outcomes
+
+
+class _InRunEvaluationCallback(CallbackBase):
+    """Evaluate in-run acquisition events when an optimization batch is complete."""
+
+    def __init__(
+        self, evaluation_function: InRunEvaluationFunction, optimizer: Optimizer, n_points: int, primary_stream: str
+    ) -> None:
+        self._evaluation_function = evaluation_function
+        self._optimizer = optimizer
+        self._n_points = n_points
+        self._primary_stream = primary_stream
+        self._start_doc: Mapping[str, Any] | None = None
+        self._descriptors: dict[str, Mapping[str, Any]] = {}
+        self._active = False
+        self._suggestions: list[dict] = []
+        self._documents: list[tuple[str, Mapping[str, Any]]] = []
+        self._events: list[Mapping[str, Any]] = []
+        self._primary_event_count = 0
+        self._outcomes: list[dict] | None = None
+        self._reference: InRunDataReference | None = None
+        self._exception: BaseException | None = None
+
+    def begin(self, suggestions: list[dict]) -> None:
+        """Start collecting documents for a new in-run evaluation batch."""
+        self._active = True
+        self._suggestions = suggestions
+        self._documents = []
+        self._events = []
+        self._primary_event_count = 0
+        self._outcomes = None
+        self._reference = None
+        self._exception = None
+
+    def complete(self) -> tuple[InRunDataReference, list[dict]]:
+        """Return the evaluated batch or raise the stored acquisition/evaluation error."""
+        if self._exception is not None:
+            raise self._exception
+        if self._reference is None or self._outcomes is None:
+            self._active = False
+            raise RuntimeError(
+                f"In-run acquisition produced {self._primary_event_count} {self._primary_stream!r} event documents, "
+                f"but n_points={self._n_points} were required for evaluation."
+            )
+        self._active = False
+        return self._reference, self._outcomes
+
+    @property
+    def evaluated(self) -> bool:
+        """Whether the active batch has already been evaluated."""
+        return self._outcomes is not None
+
+    @property
+    def failed(self) -> bool:
+        """Whether callback evaluation failed and stored an exception."""
+        return self._exception is not None
+
+    def start(self, doc: Mapping[str, Any]) -> None:
+        """Store the first enclosing optimization start document."""
+        if self._start_doc is None:
+            self._start_doc = dict(doc)
+
+    def descriptor(self, doc: Mapping[str, Any]) -> None:
+        """Store every descriptor and keep active-batch descriptor documents."""
+        copied_doc = dict(doc)
+        self._descriptors[str(copied_doc["uid"])] = copied_doc
+        if self._active:
+            self._documents.append(("descriptor", copied_doc))
+
+    def event(self, doc: Event) -> Event:
+        """Collect active-batch events and evaluate at the configured event offset."""
+        if not self._active or self._outcomes is not None:
+            return doc
+
+        copied_doc = dict(doc)
+        self._events.append(copied_doc)
+        self._documents.append(("event", copied_doc))
+        try:
+            stream_name = self._stream_name(copied_doc)
+        except BaseException as err:
+            self._exception = err
+            self._active = False
+            return doc
+        if stream_name != self._primary_stream:
+            return doc
+
+        self._primary_event_count += 1
+        if self._primary_event_count != self._n_points:
+            return doc
+
+        try:
+            reference = self._build_reference()
+            outcomes = self._evaluation_function(reference, self._suggestions)
+            _validate_outcomes_have_ids(outcomes, self._suggestions)
+            self._optimizer.ingest(outcomes)
+        except BaseException as err:
+            self._exception = err
+            self._active = False
+            return doc
+
+        self._reference = reference
+        self._outcomes = outcomes
+        self._active = False
+        return doc
+
+    def _build_reference(self) -> InRunDataReference:
+        if self._start_doc is None:
+            raise RuntimeError(
+                "In-run evaluation cannot build a reference before the optimization run start document is observed."
+            )
+
+        events = tuple(self._events)
+        stream_bounds: dict[str, tuple[int, int]] = {}
+        for event in events:
+            descriptor = self._descriptors[str(event["descriptor"])]
+            stream_name = str(descriptor["name"])
+            start = int(event["seq_num"]) - 1
+            stop = int(event["seq_num"])
+            if stream_name in stream_bounds:
+                previous_start, previous_stop = stream_bounds[stream_name]
+                stream_bounds[stream_name] = (min(previous_start, start), max(previous_stop, stop))
+            else:
+                stream_bounds[stream_name] = (start, stop)
+
+        return InRunDataReference(
+            run_uid=str(self._start_doc["uid"]),
+            start_doc=self._start_doc,
+            descriptors=dict(self._descriptors),
+            events=events,
+            documents=tuple(self._documents),
+            stream_slices={stream_name: slice(start, stop) for stream_name, (start, stop) in stream_bounds.items()},
+        )
+
+    def _stream_name(self, event: Mapping[str, Any]) -> str:
+        descriptor = self._descriptors[str(event["descriptor"])]
+        return str(descriptor["name"])
 
 
 @plan
@@ -234,6 +389,109 @@ def optimize(
 
     # Start the optimization run
     return (yield from _optimize())
+
+
+@plan
+def optimize_in_run(
+    optimization_problem: OptimizationProblem,
+    evaluation_function: InRunEvaluationFunction,
+    iterations: int = 1,
+    n_points: int = 1,
+    checkpoint_interval: int | None = None,
+    primary_stream: str = "primary",
+    readable_cache: dict[str, InferredReadable] | None = None,
+    **kwargs: Any,
+) -> MsgGenerator[None]:
+    """Solve an optimization problem by evaluating acquisition documents inside one run.
+
+    Parameters
+    ----------
+    optimization_problem : OptimizationProblem
+        The optimization problem to solve.
+    evaluation_function : InRunEvaluationFunction
+        Callable that transforms in-run Bluesky documents and suggestions into outcomes.
+    iterations : int, optional
+        The number of optimization iterations to run.
+    n_points : int, optional
+        The number of primary-stream acquisition events required before evaluating each iteration.
+    checkpoint_interval : int | None, optional
+        The number of iterations between optimizer checkpoints. If None, checkpoints
+        will not be saved. Optimizer must implement the
+        :class:`blop.protocols.Checkpointable` protocol.
+    primary_stream : str, optional
+        Acquisition stream name whose events count toward ``n_points``.
+    readable_cache: dict[str, InferredReadable] | None = None
+        Cache of readable objects to store the suggestions and outcomes as optimization events.
+        If None, a new cache will be created.
+    **kwargs : Any
+        Additional keyword arguments to pass to the acquisition plan.
+    """
+    _md = collect_optimization_metadata(optimization_problem)
+    _md.update(
+        {
+            "plan_name": "optimize_in_run",
+            "iterations": iterations,
+            "n_points": n_points,
+            "checkpoint_interval": checkpoint_interval,
+            "run_key": OPTIMIZE_IN_RUN_KEY,
+            "primary_stream": primary_stream,
+            "optimization_stream": OPTIMIZE_IN_RUN_TRACKING_STREAM,
+        }
+    )
+    readable_cache = readable_cache or {}
+
+    optimizer = optimization_problem.optimizer
+    actuators = optimization_problem.actuators
+    acquisition_plan = optimization_problem.acquisition_plan or default_acquire
+    callback = _InRunEvaluationCallback(evaluation_function, optimizer, n_points, primary_stream)
+
+    def _use_optimize_in_run_key(msg: Any) -> Any:
+        if msg.run is None:
+            return msg
+        return msg._replace(run=OPTIMIZE_IN_RUN_KEY)
+
+    @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
+    @bpp.run_decorator(md=_md)
+    def _optimize_in_run() -> MsgGenerator[None]:
+        for i in range(iterations):
+            suggestions = optimizer.suggest(n_points)
+            _validate_suggestions_have_ids(suggestions)
+            callback.begin(suggestions)
+            try:
+                yield from bpp.msg_mutator(
+                    bpp.stub_wrapper(acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)),
+                    _use_optimize_in_run_key,
+                )
+            except Exception:
+                if callback.failed:
+                    callback.complete()
+                if callback.evaluated:
+                    raise
+                if isinstance(optimizer, TrialFaultAware):
+                    optimizer.register_failures(suggestions)
+                raise
+
+            reference, outcomes = callback.complete()
+
+            yield from read_step(
+                reference.run_uid,
+                suggestions,
+                outcomes,
+                n_points,
+                readable_cache,
+                stream_name=OPTIMIZE_IN_RUN_TRACKING_STREAM,
+            )
+
+            if isinstance(optimizer, SupportsStoppingCriteria):
+                stop_now, stop_reason = optimizer.should_stop()
+                if stop_now:
+                    reason = stop_reason if stop_reason is not None else "No reason provided"
+                    logger.info(f"Global stopping triggered at iteration {i + 1}: {reason}")
+                    return
+
+            _maybe_checkpoint(optimizer, checkpoint_interval, i)
+
+    return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
 
 
 @plan

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -1,7 +1,7 @@
 """Bluesky plans for optimization."""
 
 import logging
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, MutableSequence, Sequence
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
@@ -116,7 +116,7 @@ def default_acquire(
     )
 
 
-def _validate_suggestions_have_ids(suggestions: list[dict]) -> None:
+def _validate_suggestions_have_ids(suggestions: Sequence[Mapping]) -> None:
     """Ensure every suggestion can be matched to an evaluated outcome."""
     if any(ID_KEY not in suggestion for suggestion in suggestions):
         raise ValueError(
@@ -125,7 +125,7 @@ def _validate_suggestions_have_ids(suggestions: list[dict]) -> None:
         )
 
 
-def _validate_outcomes_have_ids(outcomes: list[dict], suggestions: list[dict]) -> None:
+def _validate_outcomes_have_ids(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
     """Ensure every outcome can be matched to an optimizer suggestion."""
     if any(ID_KEY not in outcome for outcome in outcomes):
         raise ValueError(
@@ -179,83 +179,20 @@ def optimize_step(
     return uid, suggestions, outcomes
 
 
-class _InRunEvaluationCallback(CallbackBase):
-    """Evaluate in-run acquisition events when an optimization batch is complete."""
+class _DocumentCollector(CallbackBase):
+    """Collect event-model documents from a Bluesky run."""
 
     def __init__(
         self,
-        document_cache: DocumentCache | None = None,
+        document_cache: MutableSequence,
     ) -> None:
-        # Persistent arguments
         self._document_cache = document_cache
 
-        # State tracking
-        self._streams_observed: dict[str, str] = {}
-        self._uid = None
-        self._outcomes = None
-        self._active_suggestions = None
-        self._active_event_count = 0
-
-    @property
-    def run_uid(self) -> str:
-        if self._uid is None:
-            raise RuntimeError("No run is active.")
-        return self._uid
-
-    @property
-    def outcomes(self) -> list[dict]:
-        if self._outcomes is None:
-            raise RuntimeError("No outcomes are available yet.")
-        return self._outcomes
-
-    def set_ordered_suggestions(self, suggestions: list[dict]) -> None:
-        """Set the suggestions in the order that events will be emitted."""
-        self._active_suggestions = suggestions
-        self._active_event_count = 0
-
-    def start(self, doc: Mapping[str, Any]) -> None:
-        """Store the first enclosing optimization start document."""
-        if self._document_cache is not None:
-            self._document_cache.run_uid = doc["uid"]
-            self._document_cache.descriptors.clear()
-            self._document_cache.events.clear()
-            self._document_cache.suggested_events.clear()
-        # Reset state for new run
-        self._uid = doc["uid"]
-        self._active_event_count = 0
-        self._active_suggestions = None
-        self._streams_observed = {}
-        self._outcomes = None
-
-    def descriptor(self, doc: Mapping[str, Any]) -> None:
-        """Store every descriptor and keep active-batch descriptor documents."""
-        stream_uid = str(doc["uid"])
-        if self._document_cache is not None:
-            copied_doc = cast(EventDescriptor, dict(doc))
-            self._document_cache.descriptors[stream_uid] = copied_doc
-        self._streams_observed[stream_uid] = doc["name"]
-
-    def event(self, doc: Event) -> Event:
-        """Collect active-batch events and evaluate at the configured event offset."""
-        if self._active_suggestions is None:
-            raise RuntimeError(
-                "Missing call to 'set_ordered_suggestions' needed to register the active suggestions from the optimizer."
-            )
-        stream_name = self._streams_observed[doc["descriptor"]]
-        event_uid = doc["uid"]
-        if self._document_cache is not None:
-            copied_doc = cast(Event, dict(doc))
-            self._document_cache.events[event_uid] = copied_doc
-        if stream_name == self._primary_stream:
-            self._active_event_count += 1
-
-            # Cache the suggestion-event pair associated with this event
-            if self._document_cache is not None:
-                active_suggestion_idx = self._active_event_count - 1
-                suggestion_id = self._active_suggestions[active_suggestion_idx][ID_KEY]
-                self._document_cache.suggested_events.append((suggestion_id, event_uid))
-
-        return doc
+    def __call__(self, name: str, doc: dict, validate: bool = False) -> tuple[str, dict]:
+        if validate:
+            raise NotImplementedError("No document validation is implemented.")
+        self._document_cache.append((name, doc))
+        return (name, doc)
 
 
 @plan
@@ -339,8 +276,7 @@ def optimize_in_run(
     iterations: int = 1,
     n_points: int = 1,
     checkpoint_interval: int | None = None,
-    primary_stream: str = "primary",
-    document_cache: DocumentCache | None = None,
+    document_cache: MutableSequence | None = None,
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator[None]:
@@ -358,8 +294,9 @@ def optimize_in_run(
         The number of iterations between optimizer checkpoints. If None, checkpoints
         will not be saved. Optimizer must implement the
         :class:`blop.protocols.Checkpointable` protocol.
-    primary_stream: str, optional
-        Acquisition stream name whose events count toward ``n_points``.
+    document_cache : MutableSequence | None, optional
+        A shared document cache that will be filled with event-model documents from the
+        acquisition plan during the Bluesky run.
     readable_cache: dict[str, InferredReadable] | None = None
         Cache of readable objects to store the suggestions and outcomes as optimization events.
         If None, a new cache will be created.
@@ -374,7 +311,6 @@ def optimize_in_run(
             "n_points": n_points,
             "checkpoint_interval": checkpoint_interval,
             "run_key": OPTIMIZE_IN_RUN_KEY,
-            "primary_stream": primary_stream,
             "optimization_stream": OPTIMIZE_IN_RUN_TRACKING_STREAM,
         }
     )
@@ -383,26 +319,22 @@ def optimize_in_run(
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
     acquisition_plan = optimization_problem.acquisition_plan or default_acquire
-    callback = _InRunEvaluationCallback(
-        optimization_problem.evaluation_function,
-        optimizer,
-        primary_stream,
-        document_cache,
-    )
+    if document_cache is not None:
+        callback = _DocumentCollector(document_cache)
+    else:
+        callback = None
 
     def _use_optimize_in_run_key(msg: Any) -> Any:
         if msg.run is None:
             return msg
         return msg._replace(run=OPTIMIZE_IN_RUN_KEY)
 
-    @bpp.subs_decorator(callback)
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
     def _optimize_in_run() -> MsgGenerator[None]:
         for i in range(iterations):
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
-            callback.set_ordered_suggestions(suggestions)
             try:
                 uid = yield from bpp.msg_mutator(
                     bpp.stub_wrapper(acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)),
@@ -418,7 +350,7 @@ def optimize_in_run(
 
             optimizer.ingest(outcomes)
             yield from read_step(
-                callback.run_uid,
+                uid,
                 suggestions,
                 outcomes,
                 n_points,
@@ -435,6 +367,8 @@ def optimize_in_run(
 
             _maybe_checkpoint(optimizer, checkpoint_interval, i)
 
+    if callback is not None:
+        return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
     return (yield from _optimize_in_run())
 
 

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -10,7 +10,7 @@ import bluesky.preprocessors as bpp
 from bluesky.callbacks import CallbackBase
 from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
-from event_model import Event, EventDescriptor
+# from event_model import Event, EventDescriptor
 
 from .plan_stubs import read_step
 from .protocols import (
@@ -18,9 +18,7 @@ from .protocols import (
     Actuator,
     CanRegisterSuggestions,
     EvaluationFunction,
-    DocumentCache,
     OptimizationProblem,
-    Optimizer,
     Sensor,
     SupportsStoppingCriteria,
     TrialFaultAware,
@@ -270,13 +268,65 @@ def optimize(
     return (yield from _optimize())
 
 
+def acquire_stub(
+    suggestions: Sequence[Mapping],
+    actuators: Sequence[Actuator],
+    sensors: Sequence[Sensor] | None,
+    *,
+    per_step: bp.PerStep | None = None,
+) -> MsgGenerator[tuple[Any, ...]]:
+    """
+    Acquire data from suggestions and cache event-model documents in the shared store.
+
+    Parameters
+    ----------
+    suggestions
+    actuators
+    sensors
+    per_step
+
+    Returns
+    -------
+    tuple[Any, ...]
+        Suggestion IDs in the order they were evaluated, possibly re-ordered from the original sequence.
+
+    Yields
+    ------
+    Msg
+        Bluesky messages
+    """
+    if sensors is None:
+        sensors = []
+    readables = [s for s in sensors if isinstance(s, Readable)]
+    if len(readables) != len(sensors):
+        logger.warning(f"Some sensors are not readable and will be ignored. Using only the readable sensors: {readables}")
+
+    if len(suggestions) > 1:
+        if all(isinstance(actuator, Readable) for actuator in actuators):
+            current_position = yield from seq_read(cast(Sequence[Readable], actuators))
+        else:
+            current_position = None
+        suggestions = route_suggestions(suggestions, starting_position=current_position)
+
+    plan_args = _unpack_for_list_scan(suggestions, actuators)
+    # TODO: fix argument type in bluesky.plans.list_scan
+    yield from bpp.stub_wrapper(
+        bp.list_scan(
+            readables,
+            *plan_args,  # type: ignore[arg-type]
+            per_step=per_step,
+        ),
+    )
+
+    return tuple(s[ID_KEY] for s in suggestions)
+
+
 @plan
 def optimize_in_run(
     optimization_problem: OptimizationProblem,
     iterations: int = 1,
     n_points: int = 1,
     checkpoint_interval: int | None = None,
-    document_cache: MutableSequence | None = None,
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator[None]:
@@ -294,9 +344,6 @@ def optimize_in_run(
         The number of iterations between optimizer checkpoints. If None, checkpoints
         will not be saved. Optimizer must implement the
         :class:`blop.protocols.Checkpointable` protocol.
-    document_cache : MutableSequence | None, optional
-        A shared document cache that will be filled with event-model documents from the
-        acquisition plan during the Bluesky run.
     readable_cache: dict[str, InferredReadable] | None = None
         Cache of readable objects to store the suggestions and outcomes as optimization events.
         If None, a new cache will be created.
@@ -318,16 +365,13 @@ def optimize_in_run(
 
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
-    acquisition_plan = optimization_problem.acquisition_plan or default_acquire
-    if document_cache is not None:
-        callback = _DocumentCollector(document_cache)
-    else:
-        callback = None
-
-    def _use_optimize_in_run_key(msg: Any) -> Any:
-        if msg.run is None:
-            return msg
-        return msg._replace(run=OPTIMIZE_IN_RUN_KEY)
+    acquisition_plan = optimization_problem.acquisition_plan
+    if acquisition_plan is None:
+        raise RuntimeError("Must specify an acquisition plan to use 'opitmize_in_run'")
+    # if document_cache is not None:
+    #     callback = _DocumentCollector(document_cache)
+    # else:
+    #     callback = None
 
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
@@ -336,11 +380,8 @@ def optimize_in_run(
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
             try:
-                uid = yield from bpp.msg_mutator(
-                    bpp.stub_wrapper(acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)),
-                    _use_optimize_in_run_key,
-                )
-                outcomes = optimization_problem.evaluation_function(uid, suggestions)
+                uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)
+                outcomes = optimization_problem.evaluation_function(cast(Hashable, uid), suggestions)
             except Exception:
                 if isinstance(optimizer, TrialFaultAware):
                     # TODO: Is it possible to be more fine-grained than this?
@@ -367,8 +408,9 @@ def optimize_in_run(
 
             _maybe_checkpoint(optimizer, checkpoint_interval, i)
 
-    if callback is not None:
-        return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
+    # if callback is not None:
+    #     return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
+
     return (yield from _optimize_in_run())
 
 

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -4,13 +4,12 @@ import logging
 from collections.abc import Hashable, Mapping, Sequence
 from typing import Any, Literal, cast
 
-import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
 from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
 
-from .plan_stubs import read_step
+from .plan_stubs import list_scan_in_run, read_step, seq_read
 from .protocols import (
     ID_KEY,
     Actuator,
@@ -21,7 +20,16 @@ from .protocols import (
     SupportsStoppingCriteria,
     TrialFaultAware,
 )
-from .utils import InferredReadable, _maybe_checkpoint, collect_optimization_metadata, route_suggestions
+from .utils import (
+    InferredReadable,
+    _maybe_checkpoint,
+    _reject_child_run_messages,
+    _unpack_for_list_scan,
+    _validate_outcomes,
+    _validate_suggestions,
+    collect_optimization_metadata,
+    route_suggestions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,17 +38,6 @@ SAMPLE_SUGGESTIONS_RUN_KEY: Literal["sample_suggestions"] = "sample_suggestions"
 OPTIMIZE_RUN_KEY: Literal["optimize"] = "optimize"
 OPTIMIZE_IN_RUN_KEY: Literal["optimize_in_run"] = "optimize_in_run"
 OPTIMIZE_IN_RUN_TRACKING_STREAM: Literal["optimization"] = "optimization"
-
-
-def _unpack_for_list_scan(suggestions: Sequence[Mapping], actuators: Sequence[Actuator]) -> list[Any]:
-    """Unpack the actuators and inputs into Bluesky list_scan plan arguments."""
-    actuators_and_inputs = {actuator: [suggestion[actuator.name] for suggestion in suggestions] for actuator in actuators}
-    unpacked_list = []
-    for actuator, values in actuators_and_inputs.items():
-        unpacked_list.append(actuator)
-        unpacked_list.append(values)
-
-    return unpacked_list
 
 
 @plan
@@ -110,77 +107,6 @@ def default_acquire(
             _DEFAULT_ACQUIRE_RUN_KEY,
         )
     )
-
-
-def _validate_ids_are_unique_and_hashable(records: Sequence[Mapping], label: str) -> None:
-    """Ensure record IDs can be used as opaque identity values."""
-    record_ids = []
-    for record in records:
-        record_id = record[ID_KEY]
-        try:
-            hash(record_id)
-        except TypeError as err:
-            raise TypeError(f"All {label} must contain hashable '{ID_KEY}' values. Got {record_id!r}.") from err
-        record_ids.append(record_id)
-    if len(record_ids) != len(set(record_ids)):
-        raise ValueError(f"All {label} must contain unique '{ID_KEY}' values. Got {record_ids!r}.")
-
-
-def _validate_suggestions(suggestions: Sequence[Mapping]) -> None:
-    """Ensure every suggestion can be matched to an evaluated outcome."""
-    if any(ID_KEY not in suggestion for suggestion in suggestions):
-        raise ValueError(
-            f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes. Please review your "
-            f"optimizer implementation. Got suggestions: {suggestions}"
-        )
-    _validate_ids_are_unique_and_hashable(suggestions, "suggestions")
-
-
-def _validate_outcomes(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
-    """Ensure every outcome can be matched to an optimizer suggestion."""
-    if any(ID_KEY not in outcome for outcome in outcomes):
-        raise ValueError(
-            f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "
-            f"evaluation function. Got suggestions: {suggestions} and outcomes: {outcomes}"
-        )
-    _validate_ids_are_unique_and_hashable(outcomes, "outcomes")
-    suggestion_ids = {suggestion[ID_KEY] for suggestion in suggestions}
-    outcome_ids = {outcome[ID_KEY] for outcome in outcomes}
-    if suggestion_ids != outcome_ids:
-        raise ValueError(
-            "The suggestions and outcomes must contain the same IDs. Got suggestions: "
-            f"{suggestion_ids} and outcomes: {outcome_ids}"
-        )
-
-
-def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
-    """Return suggestion IDs as a hashable acquisition identifier."""
-    return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
-
-
-def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
-    """Drop child-run messages while preserving hardware lifecycle messages."""
-
-    def _drop(msg: Any) -> Any | None:
-        if msg.command in {"open_run", "close_run"}:
-            return None
-        return msg
-
-    return (yield from bpp.msg_mutator(plan, _drop))
-
-
-def _reject_child_run_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
-    """Reject child-run messages inside the optimize_in_run acquisition step."""
-
-    def _reject(msg: Any) -> Any:
-        if msg.command in {"open_run", "close_run"}:
-            raise ValueError(
-                "Custom optimize_in_run acquisition plans must not issue "
-                f"{msg.command!r}; they run inside Blop's enclosing optimization run."
-            )
-        return msg
-
-    return (yield from bpp.msg_mutator(plan, _reject))
 
 
 @plan
@@ -304,78 +230,6 @@ def optimize(
 
 
 @plan
-def default_in_run_acquire(
-    suggestions: Sequence[Mapping],
-    actuators: Sequence[Actuator],
-    sensors: Sequence[Sensor] | None = None,
-    *,
-    per_step: bp.PerStep | None = None,
-    **kwargs: Any,
-) -> MsgGenerator[tuple[Hashable, ...]]:
-    """Acquire suggestions inside an already-open Bluesky run.
-
-    This plan moves through the suggestions, optionally reordering them for efficient motion,
-    and executes a Bluesky list scan without opening a child run. The list scan's stage and
-    unstage messages are preserved.
-
-    Parameters
-    ----------
-    suggestions : Sequence[Mapping]
-        Suggested parameterizations to execute. Each suggestion must contain a hashable ``_id``.
-    actuators : Sequence[Actuator]
-        Actuators to move to the suggested positions.
-    sensors : Sequence[Sensor] | None, optional
-        Sensors that produce data to evaluate. Non-readable sensors are ignored.
-    per_step : bp.PerStep | None, optional
-        Bluesky list-scan step hook. Custom hooks may emit any number of events into any streams.
-    **kwargs : Any
-        Additional keyword arguments to pass to :func:`bluesky.plans.list_scan`.
-
-    Returns
-    -------
-    tuple[Hashable, ...]
-        Suggestion IDs in the order the suggestions were executed.
-
-        This identifier intentionally does not encode stream names, event UIDs, event counts, or
-        per-stream offsets. Custom ``per_step`` hooks may emit any number of events into any number
-        of streams. The matching evaluation function is responsible for interpreting those documents
-        and correlating them with these ordered suggestion IDs.
-
-    Yields
-    ------
-    Msg
-        Bluesky messages.
-    """
-    _validate_suggestions(suggestions)
-    if sensors is None:
-        sensors = []
-    readables = [s for s in sensors if isinstance(s, Readable)]
-    if len(readables) != len(sensors):
-        logger.warning(f"Some sensors are not readable and will be ignored. Using only the readable sensors: {readables}")
-
-    if len(suggestions) > 1:
-        if all(isinstance(actuator, Readable) for actuator in actuators):
-            current_position = yield from seq_read(cast(Sequence[Readable], actuators))
-        else:
-            current_position = None
-        suggestions = route_suggestions(suggestions, starting_position=current_position)
-
-    suggestion_ids = _suggestion_ids(suggestions)
-    plan_args = _unpack_for_list_scan(suggestions, actuators)
-    # TODO: fix argument type in bluesky.plans.list_scan
-    yield from _drop_run_control_messages(
-        bp.list_scan(
-            readables,
-            *plan_args,  # type: ignore[arg-type]
-            per_step=per_step,
-            **kwargs,
-        )
-    )
-
-    return suggestion_ids
-
-
-@plan
 def optimize_in_run(
     optimization_problem: OptimizationProblem,
     iterations: int = 1,
@@ -419,7 +273,7 @@ def optimize_in_run(
 
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
-    acquisition_plan = optimization_problem.acquisition_plan or default_in_run_acquire
+    acquisition_plan = optimization_problem.acquisition_plan or list_scan_in_run
 
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
@@ -553,27 +407,6 @@ def sample_suggestions(
         return uid, suggestions, outcomes
 
     return (yield from _inner_sample_suggestions())
-
-
-@plan
-def seq_read(readables: Sequence[Readable], **kwargs: Any) -> MsgGenerator[dict[str, Any]]:
-    """
-    Read the current values of the given readables.
-
-    Parameters
-    ----------
-    readables : Sequence[Readable]
-        The readables to read.
-
-    Returns
-    -------
-    dict[str, Any]
-        A dictionary of the readable names and their current values.
-    """
-    results = {}
-    for readable in readables:
-        results[readable.name] = yield from bps.rd(readable, **kwargs)
-    return results
 
 
 def acquire_baseline(

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -1,16 +1,14 @@
 """Bluesky plans for optimization."""
 
 import logging
-from collections.abc import Hashable, Mapping, MutableSequence, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
-from bluesky.callbacks import CallbackBase
 from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
-# from event_model import Event, EventDescriptor
 
 from .plan_stubs import read_step
 from .protocols import (
@@ -114,6 +112,20 @@ def default_acquire(
     )
 
 
+def _validate_ids_are_unique_and_hashable(records: Sequence[Mapping], label: str) -> None:
+    """Ensure record IDs can be used as opaque identity values."""
+    record_ids = []
+    for record in records:
+        record_id = record[ID_KEY]
+        try:
+            hash(record_id)
+        except TypeError as err:
+            raise TypeError(f"All {label} must contain hashable '{ID_KEY}' values. Got {record_id!r}.") from err
+        record_ids.append(record_id)
+    if len(record_ids) != len(set(record_ids)):
+        raise ValueError(f"All {label} must contain unique '{ID_KEY}' values. Got {record_ids!r}.")
+
+
 def _validate_suggestions_have_ids(suggestions: Sequence[Mapping]) -> None:
     """Ensure every suggestion can be matched to an evaluated outcome."""
     if any(ID_KEY not in suggestion for suggestion in suggestions):
@@ -121,6 +133,7 @@ def _validate_suggestions_have_ids(suggestions: Sequence[Mapping]) -> None:
             f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes. Please review your "
             f"optimizer implementation. Got suggestions: {suggestions}"
         )
+    _validate_ids_are_unique_and_hashable(suggestions, "suggestions")
 
 
 def _validate_outcomes_have_ids(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
@@ -130,6 +143,33 @@ def _validate_outcomes_have_ids(outcomes: Sequence[Mapping], suggestions: Sequen
             f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "
             f"evaluation function. Got suggestions: {suggestions} and outcomes: {outcomes}"
         )
+    _validate_ids_are_unique_and_hashable(outcomes, "outcomes")
+    suggestion_ids = {suggestion[ID_KEY] for suggestion in suggestions}
+    outcome_ids = {outcome[ID_KEY] for outcome in outcomes}
+    if suggestion_ids != outcome_ids:
+        raise ValueError(
+            "The suggestions and outcomes must contain the same IDs. Got suggestions: "
+            f"{suggestion_ids} and outcomes: {outcome_ids}"
+        )
+
+
+def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
+    """Return suggestion IDs as a hashable acquisition identifier."""
+    return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
+
+
+def _reject_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+    """Reject child-run lifecycle messages inside the optimize_in_run acquisition step."""
+
+    def _reject(msg: Any) -> Any:
+        if msg.command in {"open_run", "close_run", "stage", "unstage"}:
+            raise ValueError(
+                "Custom optimize_in_run acquisition plans must not issue "
+                f"{msg.command!r}; they run inside Blop's enclosing optimization run."
+            )
+        return msg
+
+    return (yield from bpp.msg_mutator(plan, _reject))
 
 
 @plan
@@ -175,22 +215,6 @@ def optimize_step(
     optimizer.ingest(outcomes)
 
     return uid, suggestions, outcomes
-
-
-class _DocumentCollector(CallbackBase):
-    """Collect event-model documents from a Bluesky run."""
-
-    def __init__(
-        self,
-        document_cache: MutableSequence,
-    ) -> None:
-        self._document_cache = document_cache
-
-    def __call__(self, name: str, doc: dict, validate: bool = False) -> tuple[str, dict]:
-        if validate:
-            raise NotImplementedError("No document validation is implemented.")
-        self._document_cache.append((name, doc))
-        return (name, doc)
 
 
 @plan
@@ -268,33 +292,49 @@ def optimize(
     return (yield from _optimize())
 
 
-def acquire_stub(
+@plan
+def default_in_run_acquire(
     suggestions: Sequence[Mapping],
     actuators: Sequence[Actuator],
-    sensors: Sequence[Sensor] | None,
+    sensors: Sequence[Sensor] | None = None,
     *,
     per_step: bp.PerStep | None = None,
+    **kwargs: Any,
 ) -> MsgGenerator[tuple[Hashable, ...]]:
-    """
-    Acquire data from suggestions and cache event-model documents in the shared store.
+    """Acquire suggestions inside an already-open Bluesky run.
+
+    This plan moves through the suggestions, optionally reordering them for efficient motion,
+    and executes a Bluesky list scan without opening a child run.
 
     Parameters
     ----------
-    suggestions
-    actuators
-    sensors
-    per_step
+    suggestions : Sequence[Mapping]
+        Suggested parameterizations to execute. Each suggestion must contain a hashable ``_id``.
+    actuators : Sequence[Actuator]
+        Actuators to move to the suggested positions.
+    sensors : Sequence[Sensor] | None, optional
+        Sensors that produce data to evaluate. Non-readable sensors are ignored.
+    per_step : bp.PerStep | None, optional
+        Bluesky list-scan step hook. Custom hooks may emit any number of events into any streams.
+    **kwargs : Any
+        Additional keyword arguments to pass to :func:`bluesky.plans.list_scan`.
 
     Returns
     -------
-    tuple[Any, ...]
-        Suggestion IDs in the order they were evaluated, possibly re-ordered from the original sequence.
+    tuple[Hashable, ...]
+        Suggestion IDs in the order the suggestions were executed.
+
+        This identifier intentionally does not encode stream names, event UIDs, event counts, or
+        per-stream offsets. Custom ``per_step`` hooks may emit any number of events into any number
+        of streams. The matching evaluation function is responsible for interpreting those documents
+        and correlating them with these ordered suggestion IDs.
 
     Yields
     ------
     Msg
-        Bluesky messages
+        Bluesky messages.
     """
+    _validate_suggestions_have_ids(suggestions)
     if sensors is None:
         sensors = []
     readables = [s for s in sensors if isinstance(s, Readable)]
@@ -308,6 +348,7 @@ def acquire_stub(
             current_position = None
         suggestions = route_suggestions(suggestions, starting_position=current_position)
 
+    suggestion_ids = _suggestion_ids(suggestions)
     plan_args = _unpack_for_list_scan(suggestions, actuators)
     # TODO: fix argument type in bluesky.plans.list_scan
     yield from bpp.stub_wrapper(
@@ -315,10 +356,11 @@ def acquire_stub(
             readables,
             *plan_args,  # type: ignore[arg-type]
             per_step=per_step,
+            **kwargs,
         ),
     )
 
-    return tuple(s[ID_KEY] for s in suggestions)
+    return suggestion_ids
 
 
 @plan
@@ -339,7 +381,7 @@ def optimize_in_run(
     iterations : int, optional
         The number of optimization iterations to run.
     n_points : int, optional
-        The number of primary-stream acquisition events required before evaluating each iteration.
+        The number of points to suggest per iteration.
     checkpoint_interval : int | None, optional
         The number of iterations between optimizer checkpoints. If None, checkpoints
         will not be saved. Optimizer must implement the
@@ -365,13 +407,7 @@ def optimize_in_run(
 
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
-    acquisition_plan = optimization_problem.acquisition_plan
-    if acquisition_plan is None:
-        raise RuntimeError("Must specify an acquisition plan to use 'opitmize_in_run'")
-    # if document_cache is not None:
-    #     callback = _DocumentCollector(document_cache)
-    # else:
-    #     callback = None
+    acquisition_plan = optimization_problem.acquisition_plan or default_in_run_acquire
 
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
@@ -380,8 +416,11 @@ def optimize_in_run(
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
             try:
-                uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)
-                outcomes = optimization_problem.evaluation_function(cast(Hashable, uid), suggestions)
+                uid = yield from _reject_run_control_messages(
+                    acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)
+                )
+                outcomes = optimization_problem.evaluation_function(uid, suggestions)
+                _validate_outcomes_have_ids(outcomes, suggestions)
             except Exception:
                 if isinstance(optimizer, TrialFaultAware):
                     # TODO: Is it possible to be more fine-grained than this?
@@ -407,9 +446,6 @@ def optimize_in_run(
                     return
 
             _maybe_checkpoint(optimizer, checkpoint_interval, i)
-
-    # if callback is not None:
-    #     return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
 
     return (yield from _optimize_in_run())
 

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -10,7 +10,7 @@ import bluesky.preprocessors as bpp
 from bluesky.callbacks import CallbackBase
 from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
-from event_model import Event
+from event_model import Event, EventDescriptor
 
 from .plan_stubs import read_step
 from .protocols import (
@@ -18,8 +18,7 @@ from .protocols import (
     Actuator,
     CanRegisterSuggestions,
     EvaluationFunction,
-    InRunDataReference,
-    InRunEvaluationFunction,
+    DocumentCache,
     OptimizationProblem,
     Optimizer,
     Sensor,
@@ -184,136 +183,100 @@ class _InRunEvaluationCallback(CallbackBase):
     """Evaluate in-run acquisition events when an optimization batch is complete."""
 
     def __init__(
-        self, evaluation_function: InRunEvaluationFunction, optimizer: Optimizer, n_points: int, primary_stream: str
+        self,
+        evaluation_function: EvaluationFunction,
+        optimizer: Optimizer,
+        primary_stream: str,
+        document_cache: DocumentCache | None = None,
     ) -> None:
+        # Persistent arguments
+        self._document_cache = document_cache
         self._evaluation_function = evaluation_function
         self._optimizer = optimizer
-        self._n_points = n_points
         self._primary_stream = primary_stream
-        self._start_doc: Mapping[str, Any] | None = None
-        self._descriptors: dict[str, Mapping[str, Any]] = {}
-        self._active = False
-        self._suggestions: list[dict] = []
-        self._documents: list[tuple[str, Mapping[str, Any]]] = []
-        self._events: list[Mapping[str, Any]] = []
-        self._primary_event_count = 0
-        self._outcomes: list[dict] | None = None
-        self._reference: InRunDataReference | None = None
-        self._exception: BaseException | None = None
 
-    def begin(self, suggestions: list[dict]) -> None:
-        """Start collecting documents for a new in-run evaluation batch."""
-        self._active = True
-        self._suggestions = suggestions
-        self._documents = []
-        self._events = []
-        self._primary_event_count = 0
+        # State tracking
+        self._streams_observed: dict[str, str] = {}
+        self._uid = None
         self._outcomes = None
-        self._reference = None
-        self._exception = None
-
-    def complete(self) -> tuple[InRunDataReference, list[dict]]:
-        """Return the evaluated batch or raise the stored acquisition/evaluation error."""
-        if self._exception is not None:
-            raise self._exception
-        if self._reference is None or self._outcomes is None:
-            self._active = False
-            raise RuntimeError(
-                f"In-run acquisition produced {self._primary_event_count} {self._primary_stream!r} event documents, "
-                f"but n_points={self._n_points} were required for evaluation."
-            )
-        self._active = False
-        return self._reference, self._outcomes
+        self._active_suggestions = None
+        self._active_event_count = 0
 
     @property
-    def evaluated(self) -> bool:
-        """Whether the active batch has already been evaluated."""
-        return self._outcomes is not None
+    def run_uid(self) -> str:
+        if self._uid is None:
+            raise RuntimeError("No run is active.")
+        return self._uid
 
     @property
-    def failed(self) -> bool:
-        """Whether callback evaluation failed and stored an exception."""
-        return self._exception is not None
+    def outcomes(self) -> list[dict]:
+        if self._outcomes is None:
+            raise RuntimeError("No outcomes are available yet.")
+        return self._outcomes
+
+    def set_ordered_suggestions(self, suggestions: list[dict]) -> None:
+        """Set the suggestions in the order that events will be emitted."""
+        self._active_suggestions = suggestions
+        self._active_event_count = 0
 
     def start(self, doc: Mapping[str, Any]) -> None:
         """Store the first enclosing optimization start document."""
-        if self._start_doc is None:
-            self._start_doc = dict(doc)
+        if self._document_cache is not None:
+            self._document_cache.run_uid = doc["uid"]
+            self._document_cache.descriptors.clear()
+            self._document_cache.events.clear()
+            self._document_cache.suggested_events.clear()
+        # Reset state for new run
+        self._uid = doc["uid"]
+        self._active_event_count = 0
+        self._active_suggestions = None
+        self._streams_observed = {}
+        self._outcomes = None
 
     def descriptor(self, doc: Mapping[str, Any]) -> None:
         """Store every descriptor and keep active-batch descriptor documents."""
-        copied_doc = dict(doc)
-        self._descriptors[str(copied_doc["uid"])] = copied_doc
-        if self._active:
-            self._documents.append(("descriptor", copied_doc))
+        stream_uid = str(doc["uid"])
+        if self._document_cache is not None:
+            copied_doc = cast(EventDescriptor, dict(doc))
+            self._document_cache.descriptors[stream_uid] = copied_doc
+        self._streams_observed[stream_uid] = doc["name"]
 
     def event(self, doc: Event) -> Event:
         """Collect active-batch events and evaluate at the configured event offset."""
-        if not self._active or self._outcomes is not None:
-            return doc
-
-        copied_doc = dict(doc)
-        self._events.append(copied_doc)
-        self._documents.append(("event", copied_doc))
-        try:
-            stream_name = self._stream_name(copied_doc)
-        except BaseException as err:
-            self._exception = err
-            self._active = False
-            return doc
-        if stream_name != self._primary_stream:
-            return doc
-
-        self._primary_event_count += 1
-        if self._primary_event_count != self._n_points:
-            return doc
-
-        try:
-            reference = self._build_reference()
-            outcomes = self._evaluation_function(reference, self._suggestions)
-            _validate_outcomes_have_ids(outcomes, self._suggestions)
-            self._optimizer.ingest(outcomes)
-        except BaseException as err:
-            self._exception = err
-            self._active = False
-            return doc
-
-        self._reference = reference
-        self._outcomes = outcomes
-        self._active = False
-        return doc
-
-    def _build_reference(self) -> InRunDataReference:
-        if self._start_doc is None:
+        if self._active_suggestions is None:
             raise RuntimeError(
-                "In-run evaluation cannot build a reference before the optimization run start document is observed."
+                "Missing call to 'set_ordered_suggestions' needed to register the active suggestions from the optimizer."
             )
+        stream_name = self._streams_observed[doc["descriptor"]]
+        event_uid = doc["uid"]
+        if self._document_cache is not None:
+            copied_doc = cast(Event, dict(doc))
+            self._document_cache.events[event_uid] = copied_doc
+        if stream_name == self._primary_stream:
+            self._active_event_count += 1
 
-        events = tuple(self._events)
-        stream_bounds: dict[str, tuple[int, int]] = {}
-        for event in events:
-            descriptor = self._descriptors[str(event["descriptor"])]
-            stream_name = str(descriptor["name"])
-            start = int(event["seq_num"]) - 1
-            stop = int(event["seq_num"])
-            if stream_name in stream_bounds:
-                previous_start, previous_stop = stream_bounds[stream_name]
-                stream_bounds[stream_name] = (min(previous_start, start), max(previous_stop, stop))
-            else:
-                stream_bounds[stream_name] = (start, stop)
+            # Cache the suggestion-event pair associated with this event
+            if self._document_cache is not None:
+                active_suggestion_idx = self._active_event_count - 1
+                suggestion_id = self._active_suggestions[active_suggestion_idx][ID_KEY]
+                self._document_cache.suggested_events.append((suggestion_id, event_uid))
 
-        return InRunDataReference(
-            run_uid=str(self._start_doc["uid"]),
-            start_doc=self._start_doc,
-            descriptors=dict(self._descriptors),
-            events=events,
-            documents=tuple(self._documents),
-            stream_slices={stream_name: slice(start, stop) for stream_name, (start, stop) in stream_bounds.items()},
-        )
+            # Evaluate and ingest the active batch
+            if self._active_event_count == len(self._active_suggestions):
+                # NOTE: We assume that the configured evaluation function can fetch the data from
+                # a configured cache or some external API given the Bluesky run UID.
+                outcomes = self._evaluation_function(self.run_uid, self._active_suggestions)
+                _validate_outcomes_have_ids(outcomes, self._active_suggestions)
+                self._optimizer.ingest(outcomes)
+                self._outcomes = outcomes
 
-    def _stream_name(self, event: Mapping[str, Any]) -> str:
-        descriptor = self._descriptors[str(event["descriptor"])]
-        return str(descriptor["name"])
+                # Clear active state
+                self._active_suggestions = None
+                self._active_event_count = 0
+                if self._document_cache is not None:
+                    self._document_cache.suggested_events.clear()
+
+        return doc
 
 
 @plan
@@ -394,11 +357,11 @@ def optimize(
 @plan
 def optimize_in_run(
     optimization_problem: OptimizationProblem,
-    evaluation_function: InRunEvaluationFunction,
     iterations: int = 1,
     n_points: int = 1,
     checkpoint_interval: int | None = None,
     primary_stream: str = "primary",
+    document_cache: DocumentCache | None = None,
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator[None]:
@@ -408,8 +371,6 @@ def optimize_in_run(
     ----------
     optimization_problem : OptimizationProblem
         The optimization problem to solve.
-    evaluation_function : InRunEvaluationFunction
-        Callable that transforms in-run Bluesky documents and suggestions into outcomes.
     iterations : int, optional
         The number of optimization iterations to run.
     n_points : int, optional
@@ -418,7 +379,7 @@ def optimize_in_run(
         The number of iterations between optimizer checkpoints. If None, checkpoints
         will not be saved. Optimizer must implement the
         :class:`blop.protocols.Checkpointable` protocol.
-    primary_stream : str, optional
+    primary_stream: str, optional
         Acquisition stream name whose events count toward ``n_points``.
     readable_cache: dict[str, InferredReadable] | None = None
         Cache of readable objects to store the suggestions and outcomes as optimization events.
@@ -443,40 +404,40 @@ def optimize_in_run(
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
     acquisition_plan = optimization_problem.acquisition_plan or default_acquire
-    callback = _InRunEvaluationCallback(evaluation_function, optimizer, n_points, primary_stream)
+    callback = _InRunEvaluationCallback(
+        optimization_problem.evaluation_function,
+        optimizer,
+        primary_stream,
+        document_cache,
+    )
 
     def _use_optimize_in_run_key(msg: Any) -> Any:
         if msg.run is None:
             return msg
         return msg._replace(run=OPTIMIZE_IN_RUN_KEY)
 
+    @bpp.subs_decorator(callback)
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
     def _optimize_in_run() -> MsgGenerator[None]:
         for i in range(iterations):
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
-            callback.begin(suggestions)
             try:
                 yield from bpp.msg_mutator(
                     bpp.stub_wrapper(acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)),
                     _use_optimize_in_run_key,
                 )
             except Exception:
-                if callback.failed:
-                    callback.complete()
-                if callback.evaluated:
-                    raise
                 if isinstance(optimizer, TrialFaultAware):
+                    # TODO: Is it possible to be more fine-grained than this?
                     optimizer.register_failures(suggestions)
                 raise
 
-            reference, outcomes = callback.complete()
-
             yield from read_step(
-                reference.run_uid,
+                callback.run_uid,
                 suggestions,
-                outcomes,
+                callback.outcomes,
                 n_points,
                 readable_cache,
                 stream_name=OPTIMIZE_IN_RUN_TRACKING_STREAM,
@@ -491,7 +452,7 @@ def optimize_in_run(
 
             _maybe_checkpoint(optimizer, checkpoint_interval, i)
 
-    return (yield from bpp.subs_wrapper(_optimize_in_run(), callback))
+    return (yield from _optimize_in_run())
 
 
 @plan

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -158,11 +158,22 @@ def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
     return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
 
 
-def _reject_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
-    """Reject child-run lifecycle messages inside the optimize_in_run acquisition step."""
+def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+    """Drop child-run messages while preserving hardware lifecycle messages."""
+
+    def _drop(msg: Any) -> Any | None:
+        if msg.command in {"open_run", "close_run"}:
+            return None
+        return msg
+
+    return (yield from bpp.msg_mutator(plan, _drop))
+
+
+def _reject_child_run_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+    """Reject child-run messages inside the optimize_in_run acquisition step."""
 
     def _reject(msg: Any) -> Any:
-        if msg.command in {"open_run", "close_run", "stage", "unstage"}:
+        if msg.command in {"open_run", "close_run"}:
             raise ValueError(
                 "Custom optimize_in_run acquisition plans must not issue "
                 f"{msg.command!r}; they run inside Blop's enclosing optimization run."
@@ -304,7 +315,8 @@ def default_in_run_acquire(
     """Acquire suggestions inside an already-open Bluesky run.
 
     This plan moves through the suggestions, optionally reordering them for efficient motion,
-    and executes a Bluesky list scan without opening a child run.
+    and executes a Bluesky list scan without opening a child run. The list scan's stage and
+    unstage messages are preserved.
 
     Parameters
     ----------
@@ -351,13 +363,13 @@ def default_in_run_acquire(
     suggestion_ids = _suggestion_ids(suggestions)
     plan_args = _unpack_for_list_scan(suggestions, actuators)
     # TODO: fix argument type in bluesky.plans.list_scan
-    yield from bpp.stub_wrapper(
+    yield from _drop_run_control_messages(
         bp.list_scan(
             readables,
             *plan_args,  # type: ignore[arg-type]
             per_step=per_step,
             **kwargs,
-        ),
+        )
     )
 
     return suggestion_ids
@@ -416,7 +428,7 @@ def optimize_in_run(
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
             try:
-                uid = yield from _reject_run_control_messages(
+                uid = yield from _reject_child_run_messages(
                     acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)
                 )
                 outcomes = optimization_problem.evaluation_function(uid, suggestions)

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -240,6 +240,11 @@ def optimize_in_run(
 ) -> MsgGenerator[None]:
     """Solve an optimization problem by evaluating acquisition documents inside one run.
 
+    .. warning::
+
+        This plan is **experimental**. Its API is not yet stable and may change in
+        future releases without a deprecation period.
+
     Parameters
     ----------
     optimization_problem : OptimizationProblem

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -126,7 +126,7 @@ def _validate_ids_are_unique_and_hashable(records: Sequence[Mapping], label: str
         raise ValueError(f"All {label} must contain unique '{ID_KEY}' values. Got {record_ids!r}.")
 
 
-def _validate_suggestions_have_ids(suggestions: Sequence[Mapping]) -> None:
+def _validate_suggestions(suggestions: Sequence[Mapping]) -> None:
     """Ensure every suggestion can be matched to an evaluated outcome."""
     if any(ID_KEY not in suggestion for suggestion in suggestions):
         raise ValueError(
@@ -136,7 +136,7 @@ def _validate_suggestions_have_ids(suggestions: Sequence[Mapping]) -> None:
     _validate_ids_are_unique_and_hashable(suggestions, "suggestions")
 
 
-def _validate_outcomes_have_ids(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
+def _validate_outcomes(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
     """Ensure every outcome can be matched to an optimizer suggestion."""
     if any(ID_KEY not in outcome for outcome in outcomes):
         raise ValueError(
@@ -212,7 +212,7 @@ def optimize_step(
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
     suggestions = optimizer.suggest(n_points)
-    _validate_suggestions_have_ids(suggestions)
+    _validate_suggestions(suggestions)
     try:
         uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, *args, **kwargs)
     except Exception:
@@ -222,7 +222,7 @@ def optimize_step(
 
     evaluation_function: EvaluationFunction = optimization_problem.evaluation_function
     outcomes = evaluation_function(uid, suggestions)
-    _validate_outcomes_have_ids(outcomes, suggestions)
+    _validate_outcomes(outcomes, suggestions)
     optimizer.ingest(outcomes)
 
     return uid, suggestions, outcomes
@@ -346,7 +346,7 @@ def default_in_run_acquire(
     Msg
         Bluesky messages.
     """
-    _validate_suggestions_have_ids(suggestions)
+    _validate_suggestions(suggestions)
     if sensors is None:
         sensors = []
     readables = [s for s in sensors if isinstance(s, Readable)]
@@ -426,13 +426,13 @@ def optimize_in_run(
     def _optimize_in_run() -> MsgGenerator[None]:
         for i in range(iterations):
             suggestions = optimizer.suggest(n_points)
-            _validate_suggestions_have_ids(suggestions)
+            _validate_suggestions(suggestions)
             try:
                 uid = yield from _reject_child_run_messages(
                     acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)
                 )
                 outcomes = optimization_problem.evaluation_function(uid, suggestions)
-                _validate_outcomes_have_ids(outcomes, suggestions)
+                _validate_outcomes(outcomes, suggestions)
             except Exception:
                 if isinstance(optimizer, TrialFaultAware):
                     # TODO: Is it possible to be more fine-grained than this?

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -85,6 +85,7 @@ def default_acquire(
     if len(readables) != len(sensors):
         logger.warning(f"Some sensors are not readable and will be ignored. Using only the readable sensors: {readables}")
 
+    print(f"IN default_acquire before re-ordering: {suggestions}")
     if len(suggestions) > 1:
         if all(isinstance(actuator, Readable) for actuator in actuators):
             current_position = yield from seq_read(cast(Sequence[Readable], actuators))
@@ -92,6 +93,7 @@ def default_acquire(
             current_position = None
         suggestions = route_suggestions(suggestions, starting_position=current_position)
 
+    print(f"IN default_acquire after re-ordering: {suggestions}")
     md = {"blop_suggestions": suggestions, "run_key": _DEFAULT_ACQUIRE_RUN_KEY}
     plan_args = _unpack_for_list_scan(suggestions, actuators)
     return (

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -274,7 +274,7 @@ def acquire_stub(
     sensors: Sequence[Sensor] | None,
     *,
     per_step: bp.PerStep | None = None,
-) -> MsgGenerator[tuple[Any, ...]]:
+) -> MsgGenerator[tuple[Hashable, ...]]:
     """
     Acquire data from suggestions and cache event-model documents in the shared store.
 

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -184,16 +184,10 @@ class _InRunEvaluationCallback(CallbackBase):
 
     def __init__(
         self,
-        evaluation_function: EvaluationFunction,
-        optimizer: Optimizer,
-        primary_stream: str,
         document_cache: DocumentCache | None = None,
     ) -> None:
         # Persistent arguments
         self._document_cache = document_cache
-        self._evaluation_function = evaluation_function
-        self._optimizer = optimizer
-        self._primary_stream = primary_stream
 
         # State tracking
         self._streams_observed: dict[str, str] = {}
@@ -260,21 +254,6 @@ class _InRunEvaluationCallback(CallbackBase):
                 active_suggestion_idx = self._active_event_count - 1
                 suggestion_id = self._active_suggestions[active_suggestion_idx][ID_KEY]
                 self._document_cache.suggested_events.append((suggestion_id, event_uid))
-
-            # Evaluate and ingest the active batch
-            if self._active_event_count == len(self._active_suggestions):
-                # NOTE: We assume that the configured evaluation function can fetch the data from
-                # a configured cache or some external API given the Bluesky run UID.
-                outcomes = self._evaluation_function(self.run_uid, self._active_suggestions)
-                _validate_outcomes_have_ids(outcomes, self._active_suggestions)
-                self._optimizer.ingest(outcomes)
-                self._outcomes = outcomes
-
-                # Clear active state
-                self._active_suggestions = None
-                self._active_event_count = 0
-                if self._document_cache is not None:
-                    self._document_cache.suggested_events.clear()
 
         return doc
 
@@ -423,21 +402,25 @@ def optimize_in_run(
         for i in range(iterations):
             suggestions = optimizer.suggest(n_points)
             _validate_suggestions_have_ids(suggestions)
+            callback.set_ordered_suggestions(suggestions)
             try:
-                yield from bpp.msg_mutator(
+                uid = yield from bpp.msg_mutator(
                     bpp.stub_wrapper(acquisition_plan(suggestions, actuators, optimization_problem.sensors, **kwargs)),
                     _use_optimize_in_run_key,
                 )
+                outcomes = optimization_problem.evaluation_function(uid, suggestions)
             except Exception:
                 if isinstance(optimizer, TrialFaultAware):
                     # TODO: Is it possible to be more fine-grained than this?
+                    # Some suggestions may have been acquired/evaluated without issue.
                     optimizer.register_failures(suggestions)
                 raise
 
+            optimizer.ingest(outcomes)
             yield from read_step(
                 callback.run_uid,
                 suggestions,
-                callback.outcomes,
+                outcomes,
                 n_points,
                 readable_cache,
                 stream_name=OPTIMIZE_IN_RUN_TRACKING_STREAM,

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -229,6 +229,44 @@ class EvaluationFunction(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class InRunDataReference:
+    """In-memory Bluesky documents for one in-run optimization evaluation batch.
+
+    Attributes
+    ----------
+    run_uid : str
+        UID of the enclosing optimization run.
+    start_doc : Mapping[str, Any]
+        Shallow copy of the enclosing optimization run's start document.
+    descriptors : Mapping[str, Mapping[str, Any]]
+        Shallow copies of descriptors seen so far in the enclosing run, keyed by descriptor UID.
+    events : tuple[Mapping[str, Any], ...]
+        Acquisition event documents observed for this evaluation batch before the configured primary stream reaches
+        ``n_points``. This may include non-primary streams emitted before evaluation.
+    documents : tuple[tuple[str, Mapping[str, Any]], ...]
+        Descriptor and event document pairs observed for the active acquisition batch before evaluation.
+    stream_slices : Mapping[str, slice]
+        Zero-based half-open event ranges for each stream name in ``events``.
+    """
+
+    run_uid: str
+    start_doc: Mapping[str, Any]
+    descriptors: Mapping[str, Mapping[str, Any]]
+    events: tuple[Mapping[str, Any], ...]
+    documents: tuple[tuple[str, Mapping[str, Any]], ...]
+    stream_slices: Mapping[str, slice]
+
+
+@runtime_checkable
+class InRunEvaluationFunction(Protocol):
+    """A protocol for evaluating documents collected inside an optimization run."""
+
+    def __call__(self, reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
+        """Evaluate an in-run data reference and produce one outcome per suggestion."""
+        ...
+
+
 @runtime_checkable
 class AcquisitionPlan(Protocol):
     """
@@ -319,6 +357,11 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
     immutable structure. It is typically created via :meth:`blop.ax.Agent.to_optimization_problem`
     and used with optimization plans like :func:`blop.plans.optimize`.
 
+    See Also
+    --------
+    blop.ax.Agent.to_optimization_problem : Creates an OptimizationProblem from an Agent.
+    blop.plans.optimize : Bluesky plan that uses an OptimizationProblem.
+
     Attributes
     ----------
     optimizer: Optimizer
@@ -332,11 +375,6 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
         A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
     acquisition_plan: AcquisitionPlan, optional
         A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
-
-    See Also
-    --------
-    blop.ax.Agent.to_optimization_problem : Creates an OptimizationProblem from an Agent.
-    blop.plans.optimize : Bluesky plan that uses an OptimizationProblem.
     """
 
     ...
@@ -352,6 +390,12 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     :meth:`blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem`
     and used with bluesky-queueserver-api. Actuators, sensors, and the acquisition plan are referenced
     by their names, since their instances live on a remote server.
+
+    See Also
+    --------
+    blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem :
+        Creates a QueueserverOptimizationProblem from an agent.
+    blop.queueserver.QueueserverOptimizationRunner : Runs the optimization loop using the bluesky-queueserver-api.
 
     Attributes
     ----------
@@ -369,12 +413,6 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
         The plan must match the arguments of :class:`AcquisitionPlan`.
     acquisition_plan_kwargs: Mapping[str, Any], optional
         Additional plan arguments to pass to the Bluesky plan.
-
-    See Also
-    --------
-    blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem :
-        Creates a QueueserverOptimizationProblem from an agent.
-    blop.queueserver.QueueserverOptimizationRunner : Runs the optimization loop using the bluesky-queueserver-api.
     """
 
     acquisition_plan_kwargs: Mapping[str, Any] | None = None

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -230,28 +230,6 @@ class EvaluationFunction(Protocol):
         ...
 
 
-@dataclass
-class DocumentCache:
-    """In-memory Bluesky event documents for one in-run optimization evaluation batch.
-
-    Attributes
-    ----------
-    run_uid : str
-        UID of the enclosing optimization run.
-    descriptors : Mapping[str, Mapping[str, Any]]
-        Shallow copies of descriptors seen so far in the enclosing run, keyed by descriptor UID.
-    events : MutableMapping[str, MutableSequence[Event]]
-        Shallow copies of event documents seen so far in the enclosing run, keyed by event UID.
-    suggested_events : MutableSequence[tuple[Any, str]]
-        Pairing of the *active* suggestions and their event UID.
-    """
-
-    run_uid: str
-    descriptors: MutableMapping[str, EventDescriptor]
-    events: MutableMapping[str, Event]
-    suggested_events: MutableSequence[tuple[Any, str]]
-
-
 @runtime_checkable
 class AcquisitionPlan(Protocol):
     """

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -1,12 +1,11 @@
 """Protocols that bridge between optimizer backends and Bluesky."""
 
-from collections.abc import Hashable, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Literal, Protocol, TypeVar, runtime_checkable
 
 from bluesky.protocols import EventCollectable, EventPageCollectable, Flyable, HasName, Movable, Readable
 from bluesky.utils import MsgGenerator, plan
-from event_model import Event, EventDescriptor
 
 
 @runtime_checkable
@@ -136,7 +135,8 @@ class Optimizer(Protocol):
         Suggest a set of points in the input space, to be evaulated next.
 
         The "_id" key is optional and can be used to identify suggested trials for later evaluation
-        and ingestion.
+        and ingestion. When optimization plans require IDs, each "_id" value must be unique within
+        the batch and hashable.
 
         Parameters
         ----------
@@ -147,7 +147,7 @@ class Optimizer(Protocol):
         -------
         Sequence[Mapping]
             A sequence of mappings, each containing a parameterization of a point to evaluate next.
-            Each mapping must contain a unique "_id" key to identify each parameterization.
+            Each mapping must contain a unique, hashable "_id" key to identify each parameterization.
         """
         ...
 
@@ -216,16 +216,16 @@ class EvaluationFunction(Protocol):
         ----------
         uid: Hashable
             The acquisition identifier returned by the acquisition plan. This may be a Bluesky run UID,
-            a tuple of event UIDs, or another hashable lookup key.
+            a tuple of suggestion IDs in executed order, a tuple of event UIDs, or another hashable lookup key.
         suggestions: Sequence[Mapping]
-            A sequence of mappings, each containing the parameterization of a point to evaluate.
-            The "_id" key is optional and can be used to identify each suggestion.
+            A sequence of mappings, each containing the optimizer-provided parameterization of a point to evaluate.
+            This sequence is not guaranteed to be in acquisition order. Match data and outcomes by "_id".
 
         Returns
         -------
         Sequence[Mapping]
             A sequence of mappings containing the outcomes of the acquisition, one for each suggested parameterization.
-            The "_id" key is optional and can be used to identify each outcome.
+            The "_id" key is optional and can be used to identify each outcome; when present, it must match a suggestion ID.
         """
         ...
 
@@ -237,12 +237,14 @@ class AcquisitionPlan(Protocol):
 
     This protocol defines how to acquire data from the beamline. Most users will use
     the default :func:`blop.plans.default_acquire` plan, which performs a list scan
-    over the suggested points. Custom implementations are only needed for specialized
-    acquisition strategies (e.g., fly scans, complex detector configurations).
+    in its own Bluesky run, or :func:`blop.plans.default_in_run_acquire`, which performs
+    a list scan inside an already-open optimization run. Custom implementations are only
+    needed for specialized acquisition strategies (e.g., fly scans, complex detector configurations).
 
     See Also
     --------
-    blop.plans.default_acquire : Default acquisition plan implementation.
+    blop.plans.default_acquire : Default run-owning acquisition plan implementation.
+    blop.plans.default_in_run_acquire : Default in-run acquisition plan implementation.
     blop.ax.Agent : Accepts an optional acquisition plan during initialization.
 
     Notes
@@ -264,16 +266,16 @@ class AcquisitionPlan(Protocol):
         Acquire data for optimization.
 
         This should be a Bluesky plan that moves the actuators to each of their suggested positions
-        and acquires data from the sensors. Suggestions may be re-ordered for more efficient acquisition
-        but it is the responsibility of the implementer to ensure fetching the data during
-        evaluation is feasible.
+        and acquires data from the sensors. Suggestions may be re-ordered for more efficient acquisition,
+        but it is the responsibility of the implementer to return an identifier that lets the matching
+        evaluation function correlate acquired data with suggestion IDs.
 
         Parameters
         ----------
         suggestions: Sequence[Mapping]
             A sequence of mappings, each containing the parameterization of a point to evaluate.
-            The "_id" key is optional and can be used to identify each suggestion. It is suggested
-            to add "_id" values to the run metadata for later identification of the acquired data.
+            The "_id" key is optional and can be used to identify each suggestion. When present, "_id"
+            values used by Blop optimization plans must be unique within a batch and hashable.
         actuators: Sequence[Actuator]
             The actuators to move to their suggested positions.
         sensors: Sequence[Sensor], optional
@@ -284,8 +286,8 @@ class AcquisitionPlan(Protocol):
         Returns
         -------
         Hashable
-            The identifier passed unchanged to the evaluation function. Examples include a Bluesky run UID
-            or a tuple of event UIDs.
+            The identifier passed unchanged to the evaluation function. Examples include a Bluesky run UID,
+            a tuple of suggestion IDs in executed order, a tuple of event UIDs, or another hashable lookup key.
         """
         ...
 
@@ -320,11 +322,6 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
     immutable structure. It is typically created via :meth:`blop.ax.Agent.to_optimization_problem`
     and used with optimization plans like :func:`blop.plans.optimize`.
 
-    See Also
-    --------
-    blop.ax.Agent.to_optimization_problem : Creates an OptimizationProblem from an Agent.
-    blop.plans.optimize : Bluesky plan that uses an OptimizationProblem.
-
     Attributes
     ----------
     optimizer: Optimizer
@@ -338,6 +335,11 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
         A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
     acquisition_plan: AcquisitionPlan, optional
         A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
+
+    See Also
+    --------
+    blop.ax.Agent.to_optimization_problem : Creates an OptimizationProblem from an Agent.
+    blop.plans.optimize : Bluesky plan that uses an OptimizationProblem.
     """
 
     ...
@@ -353,12 +355,6 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
     :meth:`blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem`
     and used with bluesky-queueserver-api. Actuators, sensors, and the acquisition plan are referenced
     by their names, since their instances live on a remote server.
-
-    See Also
-    --------
-    blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem :
-        Creates a QueueserverOptimizationProblem from an agent.
-    blop.queueserver.QueueserverOptimizationRunner : Runs the optimization loop using the bluesky-queueserver-api.
 
     Attributes
     ----------
@@ -376,6 +372,12 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
         The plan must match the arguments of :class:`AcquisitionPlan`.
     acquisition_plan_kwargs: Mapping[str, Any], optional
         Additional plan arguments to pass to the Bluesky plan.
+
+    See Also
+    --------
+    blop.ax.queueserver_agent.QueueserverAgent.to_optimization_problem :
+        Creates a QueueserverOptimizationProblem from an agent.
+    blop.queueserver.QueueserverOptimizationRunner : Runs the optimization loop using the bluesky-queueserver-api.
     """
 
     acquisition_plan_kwargs: Mapping[str, Any] | None = None

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -1,11 +1,12 @@
 """Protocols that bridge between optimizer backends and Bluesky."""
 
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, MutableMapping, MutableSequence, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Literal, Protocol, TypeVar, runtime_checkable
 
 from bluesky.protocols import EventCollectable, EventPageCollectable, Flyable, HasName, Movable, Readable
 from bluesky.utils import MsgGenerator, plan
+from event_model import Event, EventDescriptor
 
 
 @runtime_checkable
@@ -229,42 +230,26 @@ class EvaluationFunction(Protocol):
         ...
 
 
-@dataclass(frozen=True)
-class InRunDataReference:
-    """In-memory Bluesky documents for one in-run optimization evaluation batch.
+@dataclass
+class DocumentCache:
+    """In-memory Bluesky event documents for one in-run optimization evaluation batch.
 
     Attributes
     ----------
     run_uid : str
         UID of the enclosing optimization run.
-    start_doc : Mapping[str, Any]
-        Shallow copy of the enclosing optimization run's start document.
     descriptors : Mapping[str, Mapping[str, Any]]
         Shallow copies of descriptors seen so far in the enclosing run, keyed by descriptor UID.
-    events : tuple[Mapping[str, Any], ...]
-        Acquisition event documents observed for this evaluation batch before the configured primary stream reaches
-        ``n_points``. This may include non-primary streams emitted before evaluation.
-    documents : tuple[tuple[str, Mapping[str, Any]], ...]
-        Descriptor and event document pairs observed for the active acquisition batch before evaluation.
-    stream_slices : Mapping[str, slice]
-        Zero-based half-open event ranges for each stream name in ``events``.
+    events : MutableMapping[str, MutableSequence[Event]]
+        Shallow copies of event documents seen so far in the enclosing run, keyed by event UID.
+    suggested_events : MutableSequence[tuple[Any, str]]
+        Pairing of the *active* suggestions and their event UID.
     """
 
     run_uid: str
-    start_doc: Mapping[str, Any]
-    descriptors: Mapping[str, Mapping[str, Any]]
-    events: tuple[Mapping[str, Any], ...]
-    documents: tuple[tuple[str, Mapping[str, Any]], ...]
-    stream_slices: Mapping[str, slice]
-
-
-@runtime_checkable
-class InRunEvaluationFunction(Protocol):
-    """A protocol for evaluating documents collected inside an optimization run."""
-
-    def __call__(self, reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
-        """Evaluate an in-run data reference and produce one outcome per suggestion."""
-        ...
+    descriptors: MutableMapping[str, EventDescriptor]
+    events: MutableMapping[str, Event]
+    suggested_events: MutableSequence[tuple[Any, str]]
 
 
 @runtime_checkable

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -237,14 +237,14 @@ class AcquisitionPlan(Protocol):
 
     This protocol defines how to acquire data from the beamline. Most users will use
     the default :func:`blop.plans.default_acquire` plan, which performs a list scan
-    in its own Bluesky run, or :func:`blop.plans.default_in_run_acquire`, which performs
+    in its own Bluesky run, or :func:`blop.plan_stubs.list_scan_in_run`, which performs
     a list scan inside an already-open optimization run. Custom implementations are only
     needed for specialized acquisition strategies (e.g., fly scans, complex detector configurations).
 
     See Also
     --------
     blop.plans.default_acquire : Default run-owning acquisition plan implementation.
-    blop.plans.default_in_run_acquire : Default in-run acquisition plan implementation.
+    blop.plan_stubs.list_scan_in_run : Default in-run acquisition plan implementation.
     blop.ax.Agent : Accepts an optional acquisition plan during initialization.
 
     Notes

--- a/src/blop/tests/integration/test_simple_experiment.py
+++ b/src/blop/tests/integration/test_simple_experiment.py
@@ -9,6 +9,7 @@ from tiled.client.container import Container
 from tiled.server import SimpleTiledServer
 
 from blop.ax import Agent, Objective, RangeDOF
+from blop.plans import optimize_in_run
 
 from ..conftest import MovableSignal
 
@@ -39,6 +40,41 @@ class HimmelblauEvaluation:
             value = (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2
             outcomes.append({"_id": suggestion["_id"], "himmelblau_2d": value})
 
+        self.outcomes.extend(outcomes)
+        return outcomes
+
+
+class InRunHimmelblauEvaluation:
+    def __init__(self) -> None:
+        self.run_uid: str | None = None
+        self.primary_events: list[dict] = []
+        self._evaluated_event_count = 0
+        self.acquisition_ids: list[tuple[int, ...]] = []
+        self.outcomes: list[dict] = []
+        self._primary_descriptors: set[str] = set()
+
+    def receive_document(self, name, doc) -> None:
+        if name == "start" and doc.get("run_key") == "optimize_in_run":
+            self.run_uid = doc["uid"]
+        elif name == "descriptor" and doc["name"] == "primary":
+            self._primary_descriptors.add(doc["uid"])
+        elif name == "event" and doc["descriptor"] in self._primary_descriptors:
+            self.primary_events.append(doc["data"])
+
+    def __call__(self, uid: tuple[int, ...], suggestions: list[dict]) -> list[dict]:
+        assert set(uid) == {suggestion["_id"] for suggestion in suggestions}
+
+        events = self.primary_events[self._evaluated_event_count :]
+        assert len(events) == len(uid)
+        outcomes = []
+        for suggestion_id, event in zip(uid, events, strict=True):
+            x1 = event["x1"]
+            x2 = event["x2"]
+            value = (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2
+            outcomes.append({"_id": suggestion_id, "himmelblau_2d": value})
+
+        self._evaluated_event_count += len(events)
+        self.acquisition_ids.append(uid)
         self.outcomes.extend(outcomes)
         return outcomes
 
@@ -80,5 +116,60 @@ def test_simple_experiment_tiled_round_trip() -> None:
         assert len({outcome["_id"] for outcome in evaluation.outcomes}) == 4
         assert all(outcome["himmelblau_2d"] >= 0 for outcome in evaluation.outcomes)
         assert len(agent.ax_client.summarize()) == 4
+    finally:
+        tiled_server.close()
+
+
+def test_optimize_in_run_tiled_round_trip() -> None:
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    warnings.filterwarnings("ignore", category=FutureWarning)
+
+    tiled_server = SimpleTiledServer()
+    try:
+        tiled_client = from_uri(tiled_server.uri)
+        tiled_writer = TiledWriter(tiled_client)
+        RE = RunEngine({})
+        RE.subscribe(tiled_writer)
+
+        x1 = MovableSignal("x1", initial_value=0.1)
+        x2 = MovableSignal("x2", initial_value=0.23)
+        dofs = [
+            RangeDOF(actuator=x1, bounds=(-5, 5), parameter_type="float"),
+            RangeDOF(actuator=x2, bounds=(-5, 5), parameter_type="float"),
+        ]
+        evaluation = InRunHimmelblauEvaluation()
+        RE.subscribe(evaluation.receive_document)
+        agent = Agent(
+            sensors=[],
+            dofs=dofs,
+            objectives=[Objective(name="himmelblau_2d", minimize=True)],
+            evaluation_function=evaluation,
+            name="integration-single-run-experiment",
+            description="Scheduled integration test for single-run optimization",
+        )
+
+        # Keep each integration iteration at four points rather than crossing Ax's initialization boundary.
+        agent.ax_client.configure_generation_strategy(method="random_search", initialization_random_seed=0)
+
+        RE(optimize_in_run(agent.to_optimization_problem(), iterations=2, n_points=4))
+
+        assert evaluation.run_uid is not None
+        run = tiled_client[evaluation.run_uid]
+        assert len(tiled_client) == 1
+        assert run.start["plan_name"] == "optimize_in_run"
+        assert run.start["run_key"] == "optimize_in_run"
+        assert run.start["n_points"] == 4
+        assert run.start["optimization_stream"] == "optimization"
+        assert len(run["primary/x1"].read()) == 8
+        assert len(run["primary/x2"].read()) == 8
+        assert len(run["optimization/suggestion_ids"].read()) == 2
+        assert len(run["optimization/acquisition_uid"].read()) == 2
+        assert len(evaluation.acquisition_ids) == 2
+        assert all(len(acquisition_ids) == 4 for acquisition_ids in evaluation.acquisition_ids)
+        assert len(evaluation.primary_events) == 8
+        assert len(evaluation.outcomes) == 8
+        assert len({outcome["_id"] for outcome in evaluation.outcomes}) == 8
+        assert all(outcome["himmelblau_2d"] >= 0 for outcome in evaluation.outcomes)
+        assert len(agent.ax_client.summarize()) == 8
     finally:
         tiled_server.close()

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -5,10 +5,10 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import plan
 
+from blop.plan_stubs import list_scan_in_run
 from blop.plans import (
     acquire_baseline,
     default_acquire,
-    default_in_run_acquire,
     optimize,
     optimize_in_run,
     optimize_step,
@@ -407,7 +407,7 @@ def test_optimize_in_run_defaults_to_ordered_suggestion_ids(RE):
     assert _as_list(optimization_data["acquisition_uid"]) == ["near", "far"]
 
 
-def test_default_in_run_acquire_allows_custom_per_step_streams(RE):
+def test_list_scan_in_run_allows_custom_per_step_streams(RE):
     def per_step(detectors, step, pos_cache):
         yield from bps.one_nd_step(detectors, step, pos_cache)
         yield from bps.trigger_and_read(detectors, name="monitor")
@@ -427,7 +427,7 @@ def test_default_in_run_acquire_allows_custom_per_step_streams(RE):
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[readable],
         evaluation_function=evaluation_function,
-        acquisition_plan=default_in_run_acquire,
+        acquisition_plan=list_scan_in_run,
     )
     callback, documents = _collect_documents()
     RE.subscribe(callback)
@@ -443,7 +443,7 @@ def test_default_in_run_acquire_allows_custom_per_step_streams(RE):
     assert len(events_by_stream["optimization"]) == 1
 
 
-def test_default_in_run_acquire_preserves_stage_lifecycle(RE):
+def test_list_scan_in_run_preserves_stage_lifecycle(RE):
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
     readable = StageableReadable("objective")

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -22,7 +22,7 @@ from blop.protocols import (
     TrialFaultAware,
 )
 
-from .conftest import CheckpointableOptimizer, MovableSignal, ReadableSignal
+from .conftest import AlwaysSuccessfulStatus, CheckpointableOptimizer, MovableSignal, ReadableSignal
 
 
 @plan
@@ -465,6 +465,76 @@ def test_list_scan_in_run_allows_custom_per_step_streams(RE):
     assert len(events_by_stream["optimization"]) == 1
 
 
+def test_list_scan_in_run_accepts_no_sensors(RE):
+    movable = MovableSignal("x1", initial_value=-1.0)
+    acquisition_ids = []
+
+    @plan
+    def in_run():
+        yield from bps.open_run()
+        acquisition_ids.append((yield from list_scan_in_run([{"x1": 0.0, "_id": "point"}], [movable], sensors=None)))
+        yield from bps.close_run()
+
+    RE(in_run())
+
+    assert acquisition_ids == [("point",)]
+    assert movable._value == 0.0
+
+
+def test_list_scan_in_run_ignores_non_readable_sensors(RE, caplog):
+    class NamedOnlySensor:
+        name = "not-readable"
+
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[NamedOnlySensor()],
+        evaluation_function=evaluation_function,
+    )
+
+    RE(optimize_in_run(optimization_problem))
+
+    assert "Some sensors are not readable and will be ignored" in caplog.text
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+
+
+def test_list_scan_in_run_routes_without_actuator_readback(RE):
+    class MoveOnlySignal:
+        def __init__(self, name, initial_value):
+            self.name = name
+            self.value = initial_value
+
+        @property
+        def parent(self):
+            return None
+
+        def set(self, value):
+            self.value = value
+            return AlwaysSuccessfulStatus()
+
+    def per_step(detectors, step, pos_cache):
+        yield from bps.move_per_step(step, pos_cache)
+
+    suggestions = [{"x1": 10.0, "_id": "far"}, {"x1": 1.0, "_id": "near"}]
+    movable = MoveOnlySignal("x1", initial_value=0.0)
+    acquisition_ids = []
+
+    @plan
+    def in_run():
+        yield from bps.open_run()
+        acquisition_ids.append((yield from list_scan_in_run(suggestions, [movable], [], per_step=per_step)))
+        yield from bps.close_run()
+
+    RE(in_run())
+
+    assert set(acquisition_ids[0]) == {"far", "near"}
+    suggestion_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
+    assert movable.value == suggestion_by_id[acquisition_ids[0][-1]]["x1"]
+
+
 def test_list_scan_in_run_preserves_stage_lifecycle(RE):
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
@@ -547,21 +617,120 @@ def test_optimize_in_run_rejects_duplicate_suggestion_ids(RE):
 def test_optimize_in_run_registers_failures(RE):
     class FaultAwareOptimizer(Optimizer, TrialFaultAware): ...
 
+    suggestions = [{"x1": 0.0, "_id": 0}]
     optimizer = MagicMock(spec=FaultAwareOptimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": "same"}, {"x1": 1.0, "_id": "same"}]
-    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": "same"}])
+    optimizer.suggest.return_value = suggestions
+    evaluation_function = MagicMock(side_effect=RuntimeError("evaluation failed"))
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[ReadableSignal("objective")],
         evaluation_function=evaluation_function,
+        acquisition_plan=_test_acquisition_plan,
     )
 
-    with pytest.raises(ValueError, match="unique '_id'"):
-        RE(optimize_in_run(optimization_problem, n_points=2))
+    with pytest.raises(RuntimeError, match="evaluation failed"):
+        RE(optimize_in_run(optimization_problem))
+
+    optimizer.register_failures.assert_called_once_with(suggestions)
+    optimizer.ingest.assert_not_called()
+
+
+def test_optimize_step_rejects_suggestion_without_id(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_test_acquisition_plan,
+    )
+
+    with pytest.raises(ValueError, match="All suggestions must contain an '_id' key"):
+        RE(optimize_step(optimization_problem))
 
     evaluation_function.assert_not_called()
     optimizer.ingest.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("outcomes", "error_type", "message"),
+    [
+        ([{"objective": 0.0}, {"objective": 1.0, "_id": "b"}], ValueError, "All outcomes must contain an '_id' key"),
+        (
+            [{"objective": 0.0, "_id": []}, {"objective": 1.0, "_id": "b"}],
+            TypeError,
+            "hashable '_id'",
+        ),
+        (
+            [{"objective": 0.0, "_id": "a"}, {"objective": 1.0, "_id": "a"}],
+            ValueError,
+            "unique '_id'",
+        ),
+        (
+            [{"objective": 0.0, "_id": "a"}, {"objective": 1.0, "_id": "c"}],
+            ValueError,
+            "same IDs",
+        ),
+    ],
+)
+def test_optimize_step_rejects_invalid_outcome_ids(RE, outcomes, error_type, message):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": "a"}, {"x1": 1.0, "_id": "b"}]
+    evaluation_function = MagicMock(return_value=outcomes)
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_test_acquisition_plan,
+    )
+
+    with pytest.raises(error_type, match=message):
+        RE(optimize_step(optimization_problem, n_points=2))
+
+    evaluation_function.assert_called_once()
+    optimizer.ingest.assert_not_called()
+
+
+def test_optimize_in_run_stops_early(RE):
+    class StoppingOptimizer(Optimizer, SupportsStoppingCriteria): ...
+
+    optimizer = MagicMock(spec=StoppingOptimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    optimizer.should_stop.side_effect = [(False, None), (True, "converged")]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_test_acquisition_plan,
+    )
+
+    RE(optimize_in_run(optimization_problem, iterations=5))
+
+    assert optimizer.suggest.call_count == 2
+    assert optimizer.ingest.call_count == 2
+    assert optimizer.should_stop.call_count == 2
+
+
+def test_optimize_in_run_checkpoints(RE):
+    optimizer = MagicMock(spec=CheckpointableOptimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=MagicMock(return_value=[{"objective": 0.0, "_id": 0}]),
+        acquisition_plan=_test_acquisition_plan,
+    )
+
+    RE(optimize_in_run(optimization_problem, iterations=3, checkpoint_interval=2))
+
+    assert optimizer.checkpoint.call_count == 1
 
 
 def test_optimize_step_default(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -9,8 +9,6 @@ from blop.plans import acquire_baseline, default_acquire, optimize, optimize_in_
 from blop.protocols import (
     AcquisitionPlan,
     EvaluationFunction,
-    InRunDataReference,
-    InRunEvaluationFunction,
     OptimizationProblem,
     Optimizer,
     SupportsStoppingCriteria,
@@ -348,39 +346,37 @@ def test_optimize_with_non_checkpointable_optimizer(RE):
         RE(optimize(optimization_problem, iterations=5, n_points=2, checkpoint_interval=1))
 
 
-def test_optimize_in_run_uses_reference_and_strips_default_child_run(RE):
+def test_optimize_in_run_defaults(RE):
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    uid_evaluator = MagicMock(spec=EvaluationFunction)
     movable = MovableSignal("x1", initial_value=-1.0)
     readable = ReadableSignal("objective")
+
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+
+    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+        start_doc = [doc for doc in documents if doc[0] == "start"][0]
+        assert uid == start_doc["uid"]
+        assert suggestions == [{"x1": 0.0, "_id": 0}]
+        return [{"objective": 0.0, "_id": 0}]
+
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
         actuators=[movable],
         sensors=[readable],
-        evaluation_function=uid_evaluator,
+        evaluation_function=evaluation_function,
     )
 
-    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
-        assert isinstance(reference, InRunDataReference)
-        assert reference.run_uid == reference.start_doc["uid"]
-        assert len(reference.events) == 1
-        return [{"objective": reference.events[0]["data"]["objective"], "_id": suggestions[0]["_id"]}]
-
-    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
-    callback, documents = _collect_documents()
-    RE.subscribe(callback)
     try:
-        uids = RE(optimize_in_run(optimization_problem, in_run_evaluation_function))
+        uids = RE(optimize_in_run(optimization_problem))
     finally:
         RE.unsubscribe(callback)
 
     optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
-    uid_evaluator.assert_not_called()
     start_docs = [doc for name, doc in documents if name == "start"]
     assert len(start_docs) == 1
     assert start_docs[0]["run_key"] == "optimize_in_run"
-    assert all(doc.get("run_key") != "default_acquire" for doc in start_docs)
     assert len(uids) == 1
     events_by_stream = _events_by_stream(documents)
     assert len(events_by_stream["primary"]) == 1

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -1,4 +1,3 @@
-import functools
 from unittest.mock import MagicMock, patch
 
 import bluesky.plan_stubs as bps
@@ -8,8 +7,8 @@ from bluesky.utils import plan
 
 from blop.plans import (
     acquire_baseline,
-    acquire_stub,
     default_acquire,
+    default_in_run_acquire,
     optimize,
     optimize_in_run,
     optimize_step,
@@ -58,15 +57,6 @@ def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, 
     return _CUSTOM_ACQUISITION_IDENTIFIER
 
 
-def _three_event_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
-    """Acquisition plan that emits three primary events inside the current run."""
-    for _ in range(3):
-        for actuator in actuators:
-            if actuator.name in suggestions[0]:
-                yield from bps.mv(actuator, suggestions[0][actuator.name])
-        yield from bps.trigger_and_read(sensors or [])
-
-
 def _collect_optimize_events():
     """Return a callback and list that collect event docs from the outer optimize run."""
     events = []
@@ -103,6 +93,10 @@ def _events_by_stream(documents):
         if name == "event":
             events.setdefault(descriptors[doc["descriptor"]], []).append(doc)
     return events
+
+
+def _as_list(value):
+    return list(value) if hasattr(value, "__iter__") and not isinstance(value, str) else [value]
 
 
 @pytest.fixture(scope="function")
@@ -354,63 +348,24 @@ def test_optimize_with_non_checkpointable_optimizer(RE):
         RE(optimize(optimization_problem, iterations=5, n_points=2, checkpoint_interval=1))
 
 
-def test_optimize_in_run(RE):
+def test_optimize_in_run_defaults_to_ordered_suggestion_ids(RE):
     optimizer = MagicMock(spec=Optimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    movable = MovableSignal("x1", initial_value=-1.0)
+    optimizer.suggest.return_value = [{"x1": 10.0, "_id": "far"}, {"x1": 1.0, "_id": "near"}]
+    movable = MovableSignal("x1", initial_value=0.0)
     readable = ReadableSignal("objective")
+    captured = []
 
     callback, documents = _collect_documents()
     RE.subscribe(callback)
 
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
-        start_doc = [doc for doc in documents if doc[0] == "start"][0]
-        assert start_doc is not None
-        assert suggestions == [{"x1": 0.0, "_id": 0}]
-        return [{"objective": 0.0, "_id": 0}]
-
-    optimization_problem = OptimizationProblem(
-        optimizer=optimizer,
-        actuators=[movable],
-        sensors=[readable],
-        evaluation_function=evaluation_function,
-        acquisition_plan=acquire_stub,
-    )
-
-    try:
-        uids = RE(optimize_in_run(optimization_problem))
-    finally:
-        RE.unsubscribe(callback)
-
-    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
-    start_docs = [doc for name, doc in documents if name == "start"]
-    assert len(start_docs) == 1
-    assert start_docs[0]["run_key"] == "optimize_in_run"
-    assert len(uids) == 1
-    events_by_stream = _events_by_stream(documents)
-    assert len(events_by_stream["primary"]) == 1
-    assert len(events_by_stream["optimization"]) == 1
-    optimization_data = events_by_stream["optimization"][0]["data"]
-    assert optimization_data["suggestion_ids"] == "0"
-    assert optimization_data["acquisition_uid"] == 0
-    assert optimization_data["x1"] == 0.0
-    assert optimization_data["objective"] == 0.0
-
-
-def test_optimize_in_run_defaults(RE):
-    optimizer = MagicMock(spec=Optimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    movable = MovableSignal("x1", initial_value=-1.0)
-    readable = ReadableSignal("objective")
-
-    callback, documents = _collect_documents()
-    RE.subscribe(callback)
-
-    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
-        start_doc = [doc for doc in documents if doc[0] == "start"][0]
-        assert uid == start_doc["uid"]
-        assert suggestions == [{"x1": 0.0, "_id": 0}]
-        return [{"objective": 0.0, "_id": 0}]
+    def evaluation_function(uid: tuple[str, ...], suggestions: list[dict]) -> list[dict]:
+        captured.append((uid, suggestions))
+        events_by_stream = _events_by_stream(documents)
+        primary_values = [event["data"]["x1"] for event in events_by_stream["primary"]]
+        assert uid == ("near", "far")
+        assert suggestions == [{"x1": 10.0, "_id": "far"}, {"x1": 1.0, "_id": "near"}]
+        assert primary_values == [1.0, 10.0]
+        return [{"objective": float(index), "_id": suggestion_id} for index, suggestion_id in enumerate(uid)]
 
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
@@ -420,163 +375,116 @@ def test_optimize_in_run_defaults(RE):
     )
 
     try:
-        uids = RE(optimize_in_run(optimization_problem))
+        RE(optimize_in_run(optimization_problem, n_points=2))
     finally:
         RE.unsubscribe(callback)
 
-    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+    assert captured == [(("near", "far"), [{"x1": 10.0, "_id": "far"}, {"x1": 1.0, "_id": "near"}])]
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": "near"}, {"objective": 1.0, "_id": "far"}])
     start_docs = [doc for name, doc in documents if name == "start"]
     assert len(start_docs) == 1
     assert start_docs[0]["run_key"] == "optimize_in_run"
-    assert len(uids) == 1
     events_by_stream = _events_by_stream(documents)
-    assert len(events_by_stream["primary"]) == 1
+    assert len(events_by_stream["primary"]) == 2
     assert len(events_by_stream["optimization"]) == 1
     optimization_data = events_by_stream["optimization"][0]["data"]
-    assert optimization_data["suggestion_ids"] == "0"
-    assert optimization_data["bluesky_uid"] == uids[0]
-    assert optimization_data["x1"] == 0.0
-    assert optimization_data["objective"] == 0.0
+    assert _as_list(optimization_data["suggestion_ids"]) == ["far", "near"]
+    assert _as_list(optimization_data["acquisition_uid"]) == ["near", "far"]
 
 
-def test_optimize_in_run_strips_explicit_open_and_close_run_messages(RE):
+def test_default_in_run_acquire_allows_custom_per_step_streams(RE):
+    def per_step(detectors, step, pos_cache):
+        yield from bps.one_nd_step(detectors, step, pos_cache)
+        yield from bps.trigger_and_read(detectors, name="monitor")
+        yield from bps.trigger_and_read(detectors, name="monitor")
+
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}, {"x1": 1.0, "_id": 1}]
+    readable = ReadableSignal("objective")
+
+    def evaluation_function(uid: tuple[int, ...], suggestions: list[dict]) -> list[dict]:
+        assert uid == (0, 1)
+        assert suggestions == [{"x1": 0.0, "_id": 0}, {"x1": 1.0, "_id": 1}]
+        return [{"objective": 0.0, "_id": 0}, {"objective": 1.0, "_id": 1}]
+
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[readable],
+        evaluation_function=evaluation_function,
+        acquisition_plan=default_in_run_acquire,
+    )
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+    try:
+        RE(optimize_in_run(optimization_problem, n_points=2, per_step=per_step))
+    finally:
+        RE.unsubscribe(callback)
+
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}, {"objective": 1.0, "_id": 1}])
+    events_by_stream = _events_by_stream(documents)
+    assert len(events_by_stream["primary"]) == 2
+    assert len(events_by_stream["monitor"]) == 4
+    assert len(events_by_stream["optimization"]) == 1
+
+
+def test_optimize_in_run_rejects_child_run_control(RE):
     @plan
     def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
         yield from bps.open_run(md={"run_key": "child"})
         yield from bps.trigger_and_read(sensors or [])
         yield from bps.close_run()
+        return "child-run"
 
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
     evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
-    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[ReadableSignal("objective")],
-        evaluation_function=MagicMock(spec=EvaluationFunction),
+        evaluation_function=evaluation_function,
         acquisition_plan=acquisition_plan,
     )
 
-    callback, documents = _collect_documents()
-    RE.subscribe(callback)
-    try:
-        RE(optimize_in_run(optimization_problem, in_run_evaluation_function))
-    finally:
-        RE.unsubscribe(callback)
+    with pytest.raises(ValueError, match="must not issue 'open_run'"):
+        RE(optimize_in_run(optimization_problem))
 
-    start_docs = [doc for name, doc in documents if name == "start"]
-    assert len(start_docs) == 1
-    assert start_docs[0]["run_key"] == "optimize_in_run"
-    assert all(doc.get("run_key") != "child" for doc in start_docs)
-    evaluation_function.assert_called_once()
-    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+    evaluation_function.assert_not_called()
+    optimizer.ingest.assert_not_called()
 
 
-def test_optimize_in_run_evaluates_at_n_points_event_offset(RE):
+def test_optimize_in_run_rejects_unhashable_suggestion_ids(RE):
     optimizer = MagicMock(spec=Optimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    captured_references = []
-
-    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
-        captured_references.append(reference)
-        return [{"objective": reference.events[-1]["data"]["objective"], "_id": suggestions[0]["_id"]}]
-
-    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": ["not-hashable"]}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": ["not-hashable"]}])
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[ReadableSignal("objective")],
-        evaluation_function=MagicMock(spec=EvaluationFunction),
-        acquisition_plan=_three_event_acquisition_plan,
+        evaluation_function=evaluation_function,
     )
 
-    callback, documents = _collect_documents()
-    RE.subscribe(callback)
-    try:
-        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2))
-    finally:
-        RE.unsubscribe(callback)
+    with pytest.raises(TypeError, match="hashable '_id'"):
+        RE(optimize_in_run(optimization_problem))
 
-    assert len(captured_references) == 1
-    reference = captured_references[0]
-    assert len(reference.events) == 2
-    assert reference.stream_slices == {"primary": slice(0, 2)}
-    events_by_stream = _events_by_stream(documents)
-    assert len(events_by_stream["primary"]) == 3
-    assert len(events_by_stream["optimization"]) == 1
-    assert tuple(events_by_stream["primary"][:2]) == reference.events
+    evaluation_function.assert_not_called()
+    optimizer.ingest.assert_not_called()
 
 
-def test_optimize_in_run_uses_configured_primary_stream_for_event_offset(RE):
-    @plan
-    def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
-        sensors_by_name = {sensor.name: sensor for sensor in sensors or []}
-        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
-        yield from bps.trigger_and_read([sensors_by_name["monitor"]], name="monitor")
-        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
-        yield from bps.trigger_and_read([sensors_by_name["monitor"]], name="monitor")
-        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
-
+def test_optimize_in_run_rejects_duplicate_suggestion_ids(RE):
     optimizer = MagicMock(spec=Optimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    captured_references = []
-
-    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
-        captured_references.append(reference)
-        return [{"objective": reference.events[2]["data"]["objective"], "_id": suggestions[0]["_id"]}]
-
-    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
-    optimization_problem = OptimizationProblem(
-        optimizer=optimizer,
-        actuators=[MovableSignal("x1", initial_value=-1.0)],
-        sensors=[ReadableSignal("objective"), ReadableSignal("monitor")],
-        evaluation_function=MagicMock(spec=EvaluationFunction),
-        acquisition_plan=acquisition_plan,
-    )
-
-    callback, documents = _collect_documents()
-    RE.subscribe(callback)
-    try:
-        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2, primary_stream="monitor"))
-    finally:
-        RE.unsubscribe(callback)
-
-    assert len(captured_references) == 1
-    reference = captured_references[0]
-    descriptor_names = {doc["uid"]: doc["name"] for doc in reference.descriptors.values()}
-    assert [descriptor_names[event["descriptor"]] for event in reference.events] == [
-        "primary",
-        "monitor",
-        "primary",
-        "monitor",
-    ]
-    assert reference.stream_slices == {"primary": slice(0, 2), "monitor": slice(0, 2)}
-    events_by_stream = _events_by_stream(documents)
-    assert len(events_by_stream["primary"]) == 3
-    assert len(events_by_stream["monitor"]) == 2
-    assert len(events_by_stream["optimization"]) == 1
-
-
-def test_optimize_in_run_requires_enough_events(RE):
-    @plan
-    def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
-        yield from bps.trigger_and_read(sensors or [])
-
-    optimizer = MagicMock(spec=Optimizer)
-    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
-    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
-    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": "same"}, {"x1": 1.0, "_id": "same"}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": "same"}])
     optimization_problem = OptimizationProblem(
         optimizer=optimizer,
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[ReadableSignal("objective")],
-        evaluation_function=MagicMock(spec=EvaluationFunction),
-        acquisition_plan=acquisition_plan,
+        evaluation_function=evaluation_function,
     )
 
-    with pytest.raises(RuntimeError, match="produced 1 'primary' event documents, but n_points=2"):
-        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2))
+    with pytest.raises(ValueError, match="unique '_id'"):
+        RE(optimize_in_run(optimization_problem, n_points=2))
 
     evaluation_function.assert_not_called()
     optimizer.ingest.assert_not_called()

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -57,6 +57,21 @@ def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, 
     return _CUSTOM_ACQUISITION_IDENTIFIER
 
 
+class StageableReadable(ReadableSignal):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.stage_count = 0
+        self.unstage_count = 0
+
+    def stage(self):
+        self.stage_count += 1
+        return [self]
+
+    def unstage(self):
+        self.unstage_count += 1
+        return [self]
+
+
 def _collect_optimize_events():
     """Return a callback and list that collect event docs from the outer optimize run."""
     events = []
@@ -426,6 +441,23 @@ def test_default_in_run_acquire_allows_custom_per_step_streams(RE):
     assert len(events_by_stream["primary"]) == 2
     assert len(events_by_stream["monitor"]) == 4
     assert len(events_by_stream["optimization"]) == 1
+
+
+def test_default_in_run_acquire_preserves_stage_lifecycle(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    readable = StageableReadable("objective")
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[readable],
+        evaluation_function=MagicMock(return_value=[{"objective": 0.0, "_id": 0}]),
+    )
+
+    RE(optimize_in_run(optimization_problem))
+
+    assert readable.stage_count == 1
+    assert readable.unstage_count == 1
 
 
 def test_optimize_in_run_rejects_child_run_control(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -1,3 +1,4 @@
+import functools
 from unittest.mock import MagicMock, patch
 
 import bluesky.plan_stubs as bps
@@ -5,7 +6,14 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import plan
 
-from blop.plans import acquire_baseline, default_acquire, optimize, optimize_in_run, optimize_step
+from blop.plans import (
+    acquire_baseline,
+    acquire_stub,
+    default_acquire,
+    optimize,
+    optimize_in_run,
+    optimize_step,
+)
 from blop.protocols import (
     AcquisitionPlan,
     EvaluationFunction,
@@ -344,6 +352,49 @@ def test_optimize_with_non_checkpointable_optimizer(RE):
     )
     with pytest.raises(ValueError, match="optimizer is not checkpointable"):
         RE(optimize(optimization_problem, iterations=5, n_points=2, checkpoint_interval=1))
+
+
+def test_optimize_in_run(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    movable = MovableSignal("x1", initial_value=-1.0)
+    readable = ReadableSignal("objective")
+
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+
+    def evaluation_function(uid: str, suggestions: list[dict]) -> list[dict]:
+        start_doc = [doc for doc in documents if doc[0] == "start"][0]
+        assert start_doc is not None
+        assert suggestions == [{"x1": 0.0, "_id": 0}]
+        return [{"objective": 0.0, "_id": 0}]
+
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[movable],
+        sensors=[readable],
+        evaluation_function=evaluation_function,
+        acquisition_plan=acquire_stub,
+    )
+
+    try:
+        uids = RE(optimize_in_run(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+    start_docs = [doc for name, doc in documents if name == "start"]
+    assert len(start_docs) == 1
+    assert start_docs[0]["run_key"] == "optimize_in_run"
+    assert len(uids) == 1
+    events_by_stream = _events_by_stream(documents)
+    assert len(events_by_stream["primary"]) == 1
+    assert len(events_by_stream["optimization"]) == 1
+    optimization_data = events_by_stream["optimization"][0]["data"]
+    assert optimization_data["suggestion_ids"] == "0"
+    assert optimization_data["acquisition_uid"] == 0
+    assert optimization_data["x1"] == 0.0
+    assert optimization_data["objective"] == 0.0
 
 
 def test_optimize_in_run_defaults(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -522,6 +522,26 @@ def test_optimize_in_run_rejects_duplicate_suggestion_ids(RE):
     optimizer.ingest.assert_not_called()
 
 
+def test_optimize_in_run_registers_failures(RE):
+    class FaultAwareOptimizer(Optimizer, TrialFaultAware): ...
+
+    optimizer = MagicMock(spec=FaultAwareOptimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": "same"}, {"x1": 1.0, "_id": "same"}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": "same"}])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+    )
+
+    with pytest.raises(ValueError, match="unique '_id'"):
+        RE(optimize_in_run(optimization_problem, n_points=2))
+
+    evaluation_function.assert_not_called()
+    optimizer.ingest.assert_not_called()
+
+
 def test_optimize_step_default(RE):
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -5,10 +5,12 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import plan
 
-from blop.plans import acquire_baseline, default_acquire, optimize, optimize_step
+from blop.plans import acquire_baseline, default_acquire, optimize, optimize_in_run, optimize_step
 from blop.protocols import (
     AcquisitionPlan,
     EvaluationFunction,
+    InRunDataReference,
+    InRunEvaluationFunction,
     OptimizationProblem,
     Optimizer,
     SupportsStoppingCriteria,
@@ -50,6 +52,15 @@ def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, 
     return _CUSTOM_ACQUISITION_IDENTIFIER
 
 
+def _three_event_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that emits three primary events inside the current run."""
+    for _ in range(3):
+        for actuator in actuators:
+            if actuator.name in suggestions[0]:
+                yield from bps.mv(actuator, suggestions[0][actuator.name])
+        yield from bps.trigger_and_read(sensors or [])
+
+
 def _collect_optimize_events():
     """Return a callback and list that collect event docs from the outer optimize run."""
     events = []
@@ -66,6 +77,26 @@ def _collect_optimize_events():
             events.append(doc)
 
     return callback, events
+
+
+def _collect_documents():
+    """Return a callback and list that collect all RunEngine documents."""
+    documents = []
+
+    def callback(name, doc):
+        documents.append((name, dict(doc)))
+
+    return callback, documents
+
+
+def _events_by_stream(documents):
+    """Group event documents by descriptor stream name."""
+    descriptors = {doc["uid"]: doc["name"] for name, doc in documents if name == "descriptor"}
+    events = {}
+    for name, doc in documents:
+        if name == "event":
+            events.setdefault(descriptors[doc["descriptor"]], []).append(doc)
+    return events
 
 
 @pytest.fixture(scope="function")
@@ -315,6 +346,193 @@ def test_optimize_with_non_checkpointable_optimizer(RE):
     )
     with pytest.raises(ValueError, match="optimizer is not checkpointable"):
         RE(optimize(optimization_problem, iterations=5, n_points=2, checkpoint_interval=1))
+
+
+def test_optimize_in_run_uses_reference_and_strips_default_child_run(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    uid_evaluator = MagicMock(spec=EvaluationFunction)
+    movable = MovableSignal("x1", initial_value=-1.0)
+    readable = ReadableSignal("objective")
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[movable],
+        sensors=[readable],
+        evaluation_function=uid_evaluator,
+    )
+
+    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
+        assert isinstance(reference, InRunDataReference)
+        assert reference.run_uid == reference.start_doc["uid"]
+        assert len(reference.events) == 1
+        return [{"objective": reference.events[0]["data"]["objective"], "_id": suggestions[0]["_id"]}]
+
+    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+    try:
+        uids = RE(optimize_in_run(optimization_problem, in_run_evaluation_function))
+    finally:
+        RE.unsubscribe(callback)
+
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+    uid_evaluator.assert_not_called()
+    start_docs = [doc for name, doc in documents if name == "start"]
+    assert len(start_docs) == 1
+    assert start_docs[0]["run_key"] == "optimize_in_run"
+    assert all(doc.get("run_key") != "default_acquire" for doc in start_docs)
+    assert len(uids) == 1
+    events_by_stream = _events_by_stream(documents)
+    assert len(events_by_stream["primary"]) == 1
+    assert len(events_by_stream["optimization"]) == 1
+    optimization_data = events_by_stream["optimization"][0]["data"]
+    assert optimization_data["suggestion_ids"] == "0"
+    assert optimization_data["bluesky_uid"] == uids[0]
+    assert optimization_data["x1"] == 0.0
+    assert optimization_data["objective"] == 0.0
+
+
+def test_optimize_in_run_strips_explicit_open_and_close_run_messages(RE):
+    @plan
+    def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+        yield from bps.open_run(md={"run_key": "child"})
+        yield from bps.trigger_and_read(sensors or [])
+        yield from bps.close_run()
+
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
+    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=MagicMock(spec=EvaluationFunction),
+        acquisition_plan=acquisition_plan,
+    )
+
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+    try:
+        RE(optimize_in_run(optimization_problem, in_run_evaluation_function))
+    finally:
+        RE.unsubscribe(callback)
+
+    start_docs = [doc for name, doc in documents if name == "start"]
+    assert len(start_docs) == 1
+    assert start_docs[0]["run_key"] == "optimize_in_run"
+    assert all(doc.get("run_key") != "child" for doc in start_docs)
+    evaluation_function.assert_called_once()
+    optimizer.ingest.assert_called_once_with([{"objective": 0.0, "_id": 0}])
+
+
+def test_optimize_in_run_evaluates_at_n_points_event_offset(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    captured_references = []
+
+    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
+        captured_references.append(reference)
+        return [{"objective": reference.events[-1]["data"]["objective"], "_id": suggestions[0]["_id"]}]
+
+    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=MagicMock(spec=EvaluationFunction),
+        acquisition_plan=_three_event_acquisition_plan,
+    )
+
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+    try:
+        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2))
+    finally:
+        RE.unsubscribe(callback)
+
+    assert len(captured_references) == 1
+    reference = captured_references[0]
+    assert len(reference.events) == 2
+    assert reference.stream_slices == {"primary": slice(0, 2)}
+    events_by_stream = _events_by_stream(documents)
+    assert len(events_by_stream["primary"]) == 3
+    assert len(events_by_stream["optimization"]) == 1
+    assert tuple(events_by_stream["primary"][:2]) == reference.events
+
+
+def test_optimize_in_run_uses_configured_primary_stream_for_event_offset(RE):
+    @plan
+    def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+        sensors_by_name = {sensor.name: sensor for sensor in sensors or []}
+        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
+        yield from bps.trigger_and_read([sensors_by_name["monitor"]], name="monitor")
+        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
+        yield from bps.trigger_and_read([sensors_by_name["monitor"]], name="monitor")
+        yield from bps.trigger_and_read([sensors_by_name["objective"]], name="primary")
+
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    captured_references = []
+
+    def evaluation_function(reference: InRunDataReference, suggestions: list[dict]) -> list[dict]:
+        captured_references.append(reference)
+        return [{"objective": reference.events[2]["data"]["objective"], "_id": suggestions[0]["_id"]}]
+
+    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective"), ReadableSignal("monitor")],
+        evaluation_function=MagicMock(spec=EvaluationFunction),
+        acquisition_plan=acquisition_plan,
+    )
+
+    callback, documents = _collect_documents()
+    RE.subscribe(callback)
+    try:
+        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2, primary_stream="monitor"))
+    finally:
+        RE.unsubscribe(callback)
+
+    assert len(captured_references) == 1
+    reference = captured_references[0]
+    descriptor_names = {doc["uid"]: doc["name"] for doc in reference.descriptors.values()}
+    assert [descriptor_names[event["descriptor"]] for event in reference.events] == [
+        "primary",
+        "monitor",
+        "primary",
+        "monitor",
+    ]
+    assert reference.stream_slices == {"primary": slice(0, 2), "monitor": slice(0, 2)}
+    events_by_stream = _events_by_stream(documents)
+    assert len(events_by_stream["primary"]) == 3
+    assert len(events_by_stream["monitor"]) == 2
+    assert len(events_by_stream["optimization"]) == 1
+
+
+def test_optimize_in_run_requires_enough_events(RE):
+    @plan
+    def acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+        yield from bps.trigger_and_read(sensors or [])
+
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    evaluation_function = MagicMock(return_value=[{"objective": 0.0, "_id": 0}])
+    in_run_evaluation_function: InRunEvaluationFunction = evaluation_function
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=MagicMock(spec=EvaluationFunction),
+        acquisition_plan=acquisition_plan,
+    )
+
+    with pytest.raises(RuntimeError, match="produced 1 'primary' event documents, but n_points=2"):
+        RE(optimize_in_run(optimization_problem, in_run_evaluation_function, n_points=2))
+
+    evaluation_function.assert_not_called()
+    optimizer.ingest.assert_not_called()
 
 
 def test_optimize_step_default(RE):

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -95,13 +95,12 @@ def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Has
 
 
 def _reject_child_run_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
-    """Reject child-run messages inside the optimize_in_run acquisition step."""
+    """Reject child-run messages inside the plan."""
 
     def _reject(msg: Any) -> Any:
         if msg.command in {"open_run", "close_run"}:
             raise ValueError(
-                "Custom optimize_in_run acquisition plans must not issue "
-                f"{msg.command!r}; they run inside Blop's enclosing optimization run."
+                f"Custom acquisition plans must not issue {msg.command!r}; they run inside a Bluesky run already."
             )
         return msg
 

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -1,17 +1,19 @@
 """A set of useful helper utilities."""
 
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
+import bluesky.preprocessors as bpp
 import networkx as nx
 import numpy as np
 from bluesky.protocols import HasHints, HasParent, Hints, Readable, Reading
+from bluesky.utils import MsgGenerator
 from event_model import DataKey
 from numpy.typing import ArrayLike
 
-from .protocols import ID_KEY, Checkpointable, OptimizationProblem, Optimizer
+from .protocols import ID_KEY, Actuator, Checkpointable, OptimizationProblem, Optimizer
 
 
 class Source(StrEnum):
@@ -22,6 +24,88 @@ class Source(StrEnum):
     SUGGESTION_ID = "optimization-suggestion-id"
     ACQUISITION_UID = "optimization-acquisition-uid"
     OTHER = "optimization-other"
+
+
+def _unpack_for_list_scan(suggestions: Sequence[Mapping], actuators: Sequence[Actuator]) -> list[Any]:
+    """Unpack the actuators and inputs into Bluesky list_scan plan arguments."""
+    actuators_and_inputs = {actuator: [suggestion[actuator.name] for suggestion in suggestions] for actuator in actuators}
+    unpacked_list = []
+    for actuator, values in actuators_and_inputs.items():
+        unpacked_list.append(actuator)
+        unpacked_list.append(values)
+
+    return unpacked_list
+
+
+def _validate_ids_are_unique_and_hashable(records: Sequence[Mapping], label: str) -> None:
+    """Ensure record IDs can be used as opaque identity values."""
+    record_ids = []
+    for record in records:
+        record_id = record[ID_KEY]
+        try:
+            hash(record_id)
+        except TypeError as err:
+            raise TypeError(f"All {label} must contain hashable '{ID_KEY}' values. Got {record_id!r}.") from err
+        record_ids.append(record_id)
+    if len(record_ids) != len(set(record_ids)):
+        raise ValueError(f"All {label} must contain unique '{ID_KEY}' values. Got {record_ids!r}.")
+
+
+def _validate_suggestions(suggestions: Sequence[Mapping]) -> None:
+    """Ensure every suggestion can be matched to an evaluated outcome."""
+    if any(ID_KEY not in suggestion for suggestion in suggestions):
+        raise ValueError(
+            f"All suggestions must contain an '{ID_KEY}' key to later match with the outcomes. Please review your "
+            f"optimizer implementation. Got suggestions: {suggestions}"
+        )
+    _validate_ids_are_unique_and_hashable(suggestions, "suggestions")
+
+
+def _validate_outcomes(outcomes: Sequence[Mapping], suggestions: Sequence[Mapping]) -> None:
+    """Ensure every outcome can be matched to an optimizer suggestion."""
+    if any(ID_KEY not in outcome for outcome in outcomes):
+        raise ValueError(
+            f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "
+            f"evaluation function. Got suggestions: {suggestions} and outcomes: {outcomes}"
+        )
+    _validate_ids_are_unique_and_hashable(outcomes, "outcomes")
+    suggestion_ids = {suggestion[ID_KEY] for suggestion in suggestions}
+    outcome_ids = {outcome[ID_KEY] for outcome in outcomes}
+    if suggestion_ids != outcome_ids:
+        raise ValueError(
+            "The suggestions and outcomes must contain the same IDs. Got suggestions: "
+            f"{suggestion_ids} and outcomes: {outcome_ids}"
+        )
+
+
+def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
+    """Return suggestion IDs as a hashable acquisition identifier."""
+    return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
+
+
+def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+    """Drop child-run messages while preserving hardware lifecycle messages."""
+
+    def _drop(msg: Any) -> Any | None:
+        if msg.command in {"open_run", "close_run"}:
+            return None
+        return msg
+
+    return (yield from bpp.msg_mutator(plan, _drop))
+
+
+def _reject_child_run_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+    """Reject child-run messages inside the optimize_in_run acquisition step."""
+
+    def _reject(msg: Any) -> Any:
+        if msg.command in {"open_run", "close_run"}:
+            raise ValueError(
+                "Custom optimize_in_run acquisition plans must not issue "
+                f"{msg.command!r}; they run inside Blop's enclosing optimization run."
+            )
+        return msg
+
+    return (yield from bpp.msg_mutator(plan, _reject))
 
 
 def _maybe_checkpoint(optimizer: Optimizer, checkpoint_interval: int | None, iteration: int) -> None:

--- a/src/blop/xopt/optimizer.py
+++ b/src/blop/xopt/optimizer.py
@@ -128,7 +128,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
     def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Register external suggestions with the optimizer."""
         # Attach stable blop trial IDs and cache suggested parameterizations by ID.
-        registered: Sequence[Mapping] = []
+        registered: list[dict] = []
         for suggestion in suggestions:
             trial_id = self._next_id
             self._next_id += 1

--- a/src/blop/xopt/optimizer.py
+++ b/src/blop/xopt/optimizer.py
@@ -128,7 +128,7 @@ class XoptOptimizer(Optimizer, Checkpointable, CanRegisterSuggestions, TrialFaul
     def register_suggestions(self, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Register external suggestions with the optimizer."""
         # Attach stable blop trial IDs and cache suggested parameterizations by ID.
-        registered: list[dict] = []
+        registered: Sequence[Mapping] = []
         for suggestion in suggestions:
             trial_id = self._next_id
             self._next_id += 1


### PR DESCRIPTION
# Summary

Minimal implementation of a plan that does the optimization loop within a single run, without altering Blop's core protocols or inventing new ones. This is unlike `blop.plans.optimize` which opens Bluesky runs in parallel (one outer run, many inner runs). Now, there is only one single run, and the optimization data is collected into a separate event stream called "optimization".

This PR mostly sets the stage for future work that will make single-run optimization easier to use.

Closes #336 

# Detailed Changes

- New plan: `blop.plans.optimize_in_run` which implements the optimization loop (similar to `blop.plans.optimize` and `blop.plans.optimize_step`).
- New stub: `blop.plan_stubs.list_scan_in_run` which is a version of list scan (similar to `blop.plans.default_acquire`) that strips out `'open_run'` and `'close_run'` messages normally created by the `bluesky.plans.list_scan`.
  - I intentionally avoided using `bluesky.preprocessors.stub_wrapper` here because that also strips `'stage'` and `'unstage'` messages. Potentially lengthy operations such as the evaluation function, outcome ingestion, or next suggestions may require that devices be unstaged.
- Validate that suggestion IDs are unique and `Hashable` both after `optimizer.suggest()` and evaluation.
- Moved around utilities and helper plan stubs to better file locations
- Various updates to the docs explaining the relationship between acquisition plans and evaluation functions, grounded in this new example of optimization within a single run.

# Future Work

This PR opens the door to a significant chunk of potential future work. Once this PR is merged, we should open these as Issues.
- Refactoring common operations between `blop.plans.optimize`, `blop.plans.optimize_in_run`, `blop.plans.optimize_step`, `blop.plans.default_acquire`, and `blop.plan_stubs.list_scan_in_run`. As is, this PR will duplicate some code in some places.
- Blop's callback router should support `optimize_in_run` by allowing the `optimization` stream to pass through the filter.
  - A new logging callback may be nice for `optimize_in_run` if the current one doesn't fit or refactor nicely.
- A version of `blop.plans.optimize_in_run` that stages/unstages devices only once for the entire run. Current design is to stage/unstage every iteration. This behavior should be opt-in and explicitly documented.
- Expose `blop.plans.optimize_in_run` in the Ax agent (not the queueserver one)
- In the spirit of #229 and #300 , write evaluation function helpers or base classes that would assist users with juggling IDs between acquisition plans and evaluation functions and fetching their data
  - Document callback one that keeps an in-memory store of documents
  - Tiled streaming one that sets up subscriptions using the Tiled client
  - These likely can't apply to every possible situation, but we should try to target the most common cases, such as:
     - One suggestion <-> one Bluesky event
     - One suggestion <-> one Tiled client update (from Tiled subscriptions)