### PR TITLE
fix(plans): register evaluation failures

### DIFF
--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -145,12 +145,12 @@ def optimize_step(
         )
     try:
         uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, *args, **kwargs)
+        outcomes = optimization_problem.evaluation_function(uid, suggestions)
     except Exception:
         if isinstance(optimizer, TrialFaultAware):
             optimizer.register_failures(suggestions)
         raise
 
-    outcomes = optimization_problem.evaluation_function(uid, suggestions)
     if any(ID_KEY not in outcome for outcome in outcomes):
         raise ValueError(
             f"All outcomes must contain an '{ID_KEY}' key that matches with the suggestions. Please review your "

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -136,6 +136,28 @@ def test_optimization_failure(RE):
     assert evaluation_function.call_count == 0
 
 
+def test_evaluation_failure_registers_suggestions(RE):
+    class Alpha(Optimizer, TrialFaultAware): ...
+
+    suggestions = [{"x1": 0.0, "_id": 0}]
+    optimizer = MagicMock(spec=Alpha)
+    optimizer.suggest.return_value = suggestions
+    evaluation_function = MagicMock(spec=EvaluationFunction, side_effect=RuntimeError("evaluation failed"))
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_test_acquisition_plan,
+    )
+
+    with pytest.raises(RuntimeError, match="evaluation failed"):
+        RE(optimize_step(optimization_problem))
+
+    optimizer.register_failures.assert_called_once_with(suggestions)
+    optimizer.ingest.assert_not_called()
+
+
 def test_optimize_multiple(RE):
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]


### PR DESCRIPTION
## Summary

- register suggested points as failures when evaluation raises
- preserve the original evaluation exception and skip ingestion
- add regression coverage for evaluation failures

## Testing

- 269 non-integration tests passed
- Ruff formatting and lint passed
- Pyright passed
- All pre-commit hooks passed

Fixes #354