### PR TITLE
Prevent route suggestions from revisiting a suggestion twice

### DIFF
--- a/src/blop/tests/test_utils.py
+++ b/src/blop/tests/test_utils.py
@@ -73,6 +73,29 @@ def test_route_suggestions_multiple_with_start():
     assert len(result) == 2
 
 
+def test_route_suggestions_visits_each_reported_suggestion_once():
+    suggestions = [
+        {ID_KEY: 0, "big_r": 152982.84327559808, "toroid_focus:toroidMirror01:r": 1162.0765699687756},
+        {ID_KEY: 1, "big_r": 161916.56982474664, "toroid_focus:toroidMirror01:r": 1488.1603493037976},
+        {ID_KEY: 2, "big_r": 139461.95450559893, "toroid_focus:toroidMirror01:r": 798.5515472161926},
+        {ID_KEY: 3, "big_r": 150664.77394611278, "toroid_focus:toroidMirror01:r": 1403.9407343286432},
+        {ID_KEY: 4, "big_r": 158210.14488064387, "toroid_focus:toroidMirror01:r": 960.4307756441988},
+        {ID_KEY: 5, "big_r": 155033.62997383514, "toroid_focus:toroidMirror01:r": 1226.6657248753465},
+        {ID_KEY: 6, "big_r": 147491.13174103835, "toroid_focus:toroidMirror01:r": 1041.026067795173},
+        {ID_KEY: 7, "big_r": 143785.51106848457, "toroid_focus:toroidMirror01:r": 1654.6320047843612},
+        {ID_KEY: 8, "big_r": 166242.9699762229, "toroid_focus:toroidMirror01:r": 722.9002070295967},
+        {ID_KEY: 9, "big_r": 165175.66349305847, "toroid_focus:toroidMirror01:r": 1338.998358571843},
+    ]
+    start = {"big_r": 150000.0, "toroid_focus:toroidMirror01:r": 1500.0}
+
+    result = route_suggestions(suggestions, starting_position=start)
+    routed_ids = [suggestion[ID_KEY] for suggestion in result]
+
+    assert routed_ids[0] == 3
+    assert len(routed_ids) == len(suggestions)
+    assert set(routed_ids) == {suggestion[ID_KEY] for suggestion in suggestions}
+
+
 # _infer_data_key source value tests
 
 

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -154,12 +154,6 @@ def _validate_route_index(index: Sequence[int], num_points: int) -> list[int]:
     return route
 
 
-def _remove_longest_cycle_edge(cycle: Sequence[int], graph: nx.DiGraph) -> list[int]:
-    """Convert a Hamiltonian cycle into an open path by removing its longest edge."""
-    longest_edge_index = max(range(len(cycle) - 1), key=lambda index: graph[cycle[index]][cycle[index + 1]]["weight"])
-    return list(cycle[longest_edge_index + 1 : -1]) + list(cycle[: longest_edge_index + 1])
-
-
 def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = None) -> list[int]:
     num_suggestions = len(points)
     if num_suggestions < 2:
@@ -173,18 +167,14 @@ def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = Non
             d = np.sqrt(np.sum(np.square(i_point - j_point)))
             graph.add_edge(i, j, weight=d)
 
-    if starting_point is None:
-        cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", seed=0)
-        index = _remove_longest_cycle_edge(cycle, graph)
-    else:
-        start_node = num_suggestions
-        for i, point in enumerate(points):
-            d = np.sqrt(np.sum(np.square(starting_point - point)))
-            graph.add_edge(start_node, i, weight=d)
-            graph.add_edge(i, start_node, weight=0.0)
+    anchor_node = num_suggestions
+    for i, point in enumerate(points):
+        d = 0.0 if starting_point is None else np.sqrt(np.sum(np.square(starting_point - point)))
+        graph.add_edge(anchor_node, i, weight=d)
+        graph.add_edge(i, anchor_node, weight=0.0)
 
-        cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", source=start_node, seed=0)
-        index = list(cycle[1:-1])
+    cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", source=anchor_node, seed=0)
+    index = list(cycle[1:-1])
 
     return _validate_route_index(index, num_suggestions)
 

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -134,30 +134,63 @@ class InferredReadable(Readable, HasHints, HasParent):
         }
 
 
-def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = None):
-    if starting_point is not None:
-        points = np.concatenate([starting_point[None], points], axis=0)
+def _validate_route_index(index: Sequence[int], num_points: int) -> list[int]:
+    """Validate that a route visits every suggestion once."""
+    route = list(index)
+    counts: dict[int, int] = {}
+    for point_index in route:
+        counts[point_index] = counts.get(point_index, 0) + 1
 
-    G = nx.DiGraph()
+    expected = set(range(num_points))
+    seen = set(counts)
+    if seen != expected or len(route) != num_points:
+        missing = sorted(expected - seen)
+        duplicates = sorted(point_index for point_index, count in counts.items() if count > 1)
+        raise RuntimeError(
+            "TSP solver returned an invalid route. "
+            f"Missing point indices {missing!r}; duplicate point indices {duplicates!r}; route {route!r}."
+        )
+
+    return route
+
+
+def _remove_longest_cycle_edge(cycle: Sequence[int], graph: nx.DiGraph) -> list[int]:
+    """Convert a Hamiltonian cycle into an open path by removing its longest edge."""
+    longest_edge_index = max(range(len(cycle) - 1), key=lambda index: graph[cycle[index]][cycle[index + 1]]["weight"])
+    return list(cycle[longest_edge_index + 1 : -1]) + list(cycle[: longest_edge_index + 1])
+
+
+def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = None) -> list[int]:
+    num_suggestions = len(points)
+    if num_suggestions < 2:
+        return list(range(num_suggestions))
+
+    graph = nx.DiGraph()
     for i, i_point in enumerate(points):
         for j, j_point in enumerate(points):
-            if j <= i:
+            if i == j:
                 continue
             d = np.sqrt(np.sum(np.square(i_point - j_point)))
-            G.add_edge(i, j, weight=d)
-            G.add_edge(j, i, weight=d if i > 0 else 1e2 * d)
+            graph.add_edge(i, j, weight=d)
 
-    index = nx.approximation.traveling_salesman_problem(
-        G, cycle=False, method=nx.approximation.simulated_annealing_tsp, init_cycle="greedy"
-    )
+    if starting_point is None:
+        cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", seed=0)
+        index = _remove_longest_cycle_edge(cycle, graph)
+    else:
+        start_node = num_suggestions
+        for i, point in enumerate(points):
+            d = np.sqrt(np.sum(np.square(starting_point - point)))
+            graph.add_edge(start_node, i, weight=d)
+            graph.add_edge(i, start_node, weight=0.0)
 
-    if starting_point is not None:
-        index = [i - 1 for i in index if i > 0]
-    return index
+        cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", source=start_node, seed=0)
+        index = list(cycle[1:-1])
+
+    return _validate_route_index(index, num_suggestions)
 
 
 def route_suggestions(suggestions: Sequence[Mapping], starting_position: dict | None = None):
-    """Route suggestions using networkx TSP solver."""
+    """Route suggestions through a shortest open path over routed dimensions."""
     if len(suggestions) == 1:
         return suggestions
 


### PR DESCRIPTION
It was creating cycles in edge cases causing duplicate visits to the same suggestion.

Discussed with @MTakahashi-KWH in-person.