### PR TITLE
Promote unicode numpy dtypes to at most 36 characters long

### DIFF
--- a/src/blop/tests/test_utils.py
+++ b/src/blop/tests/test_utils.py
@@ -22,6 +22,7 @@ def test_inferred_readable_scalar_string():
     r = InferredReadable("ids", Source.OTHER, ["0"])
     assert r.read()["ids"]["value"] == "0"
     assert r.describe()["ids"]["dtype"] == "string"
+    assert r.describe()["ids"]["dtype_numpy"] == "<U36"
 
 
 def test_inferred_readable_array():

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -37,7 +37,10 @@ def _maybe_checkpoint(optimizer: Optimizer, checkpoint_interval: int | None, ite
 def _infer_data_key(source: Source, value: ArrayLike) -> DataKey:
     """Infer the data key from the provided value."""
     numpy_array = np.array(value)
-    dtype_numpy = numpy_array.dtype.str
+    # Descriptions are cached across updates, so reserve enough space for UUIDs.
+    dtype_numpy = (
+        np.promote_types(numpy_array.dtype, np.dtype("<U36")).str if numpy_array.dtype.kind == "U" else numpy_array.dtype.str
+    )
     if len(numpy_array.shape) > 1 or (len(numpy_array.shape) == 1 and numpy_array.shape[0] > 1):
         dtype = "array"
         shape = list(numpy_array.shape)


### PR DESCRIPTION
Assisted-by: oh-my-pi:gpt-5.6-sol

Closes #362 