### PR TITLE
Add 'blop_acquisition_order' metadata for suggestion reordering

### DIFF
--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -22,8 +22,8 @@ In these situations, users can implement a custom acquisition plan that
 translates optimization variables into the corresponding physical operations.
 The trade-off is that the custom plan becomes responsible for maintaining the
 association between optimizer suggestions and the acquired data within the
-chosen storage or event system (typically stashing the suggestions in proper 
-order in storage or tagging the run markdown).
+chosen storage or event system, for example by storing suggestion IDs in
+acquisition order in the run metadata.
 
 The plan must return a hashable acquisition identifier. Blop passes that value
 unchanged to the evaluation function. A Bluesky run UID is the usual identifier,
@@ -49,7 +49,7 @@ the full physical coordinate system is shown below.
             md: Mapping[str, Any] | None = None,
         ) -> MsgGenerator[Hashable]:
 
-            coords = [subspace_to_real(s) for s in suggestions]
+            coords = [{**subspace_to_real(s), "_id": s["_id"]} for s in suggestions]
             return (yield from default_acquire(
                 coords,
                 actuators,
@@ -61,6 +61,10 @@ Wrapping the default acquire function is completely acceptable for coordinate to
 coordinate schemes to keep default acquire's convenience. Just remember that 
 systems like Tiled will report your converted coordinates in their suggestion 
 history during evaluation.
+
+``default_acquire`` also records those IDs under ``blop_acquisition_order`` so
+the evaluator can associate each acquired row with the original suggestion.
+
 
 Virtual Coordinate Systems
 --------------------------

--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -23,7 +23,9 @@ translates optimization variables into the corresponding physical operations.
 The trade-off is that the custom plan becomes responsible for maintaining the
 association between optimizer suggestions and the acquired data within the
 chosen storage or event system, for example by storing suggestion IDs in
-acquisition order in the run metadata.
+actual acquisition order in the run metadata. The evaluator's ``suggestions``
+sequence is not an acquisition-order contract and must not be assumed to
+preserve the optimizer's generation order.
 
 The plan must return a hashable acquisition identifier. Blop passes that value
 unchanged to the evaluation function. A Bluesky run UID is the usual identifier,
@@ -62,8 +64,9 @@ coordinate schemes to keep default acquire's convenience. Just remember that
 systems like Tiled will report your converted coordinates in their suggestion 
 history during evaluation.
 
-``default_acquire`` also records those IDs under ``blop_acquisition_order`` so
-the evaluator can associate each acquired row with the original suggestion.
+``default_acquire`` records IDs in actual scan order under ``blop_acquisition_order``.
+Evaluators must use this ID sequence, not positions in ``suggestions``, to associate
+acquired rows. Custom plans that reorder points must record an equivalent sequence themselves.
 
 
 Virtual Coordinate Systems

--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -23,9 +23,7 @@ translates optimization variables into the corresponding physical operations.
 The trade-off is that the custom plan becomes responsible for maintaining the
 association between optimizer suggestions and the acquired data within the
 chosen storage or event system, for example by storing suggestion IDs in
-actual acquisition order in the run metadata. The evaluator's ``suggestions``
-sequence is not an acquisition-order contract and must not be assumed to
-preserve the optimizer's generation order.
+actual acquisition order in the run metadata.
 
 The plan must return a hashable acquisition identifier. Blop passes that value
 unchanged to the evaluation function. A Bluesky run UID is the usual identifier
@@ -66,9 +64,8 @@ coordinate schemes to keep default acquire's convenience. Just remember that
 systems like Tiled will report your converted coordinates in their suggestion 
 history during evaluation.
 
-``default_acquire`` records IDs in actual scan order under ``blop_acquisition_order``.
-Evaluators must use this ID sequence, not positions in ``suggestions``, to associate
-acquired rows. Custom plans that reorder points must record an equivalent sequence themselves.
+``default_acquire`` also records those IDs under ``blop_acquisition_order`` so
+the evaluator can associate each acquired row with the original suggestion.
 
 
 Virtual Coordinate Systems

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -12,7 +12,7 @@ commonly used at beamlines while also supporting data acquired within a single B
 Anatomy of an Evaluation Function
 ---------------------------------
 
-An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. Suggestions are optional analysis context, and their order is neither an acquisition-order contract nor a guaranteed optimizer-generation order. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
+An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. Suggestions are optional analysis context and are not guaranteed to match the order of the acquired data. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
 
 A typical implementation is shown below:
 

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -39,8 +39,9 @@ A typical implementation is shown below:
             #
             # Typical responsibilities include:
             #   - Retrieving the data associated with the identifier
-            #   - Iterating over individual suggestions in the acquisition
-            #       - found in a run's start document under "blop_suggestions" when using default_acquire
+            #   - Matching each acquired sample to the suggestions argument
+            #       - IDs are stored in acquisition order under "blop_acquisition_order"
+            #         in the run's start document when using default_acquire
             #   - Constructing a per-suggestion analysis context
             #   - Calling a lower-level objective function for each sample or suggestion
 

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -12,7 +12,7 @@ commonly used at beamlines while also supporting data acquired within a single B
 Anatomy of an Evaluation Function
 ---------------------------------
 
-An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
+An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. Suggestions are optional analysis context, and their order is neither an acquisition-order contract nor a guaranteed optimizer-generation order. The identifier may be a Bluesky run UID, a tuple of event UIDs, or another hashable key understood by the evaluator.
 
 A typical implementation is shown below:
 
@@ -39,10 +39,10 @@ A typical implementation is shown below:
             #
             # Typical responsibilities include:
             #   - Retrieving the data associated with the identifier
-            #   - Matching each acquired sample to the suggestions argument
-            #       - IDs are stored in acquisition order under "blop_acquisition_order"
+            #   - Matching each acquired sample to its optimizer trial ID
+            #       - IDs are stored in actual acquisition order under "blop_acquisition_order"
             #         in the run's start document when using default_acquire
-            #   - Constructing a per-suggestion analysis context
+            #   - Treating suggestions as optional context, never matching by list position
             #   - Calling a lower-level objective function for each sample or suggestion
 
 Although the interface is intentionally minimal, separating setup from

--- a/docs/source/how-to-guides/use-tiled.rst
+++ b/docs/source/how-to-guides/use-tiled.rst
@@ -89,12 +89,13 @@ To access the data for optimization, you have to connect to a Tiled server insta
 Data Storage with Blop's Default Plans
 ---------------------------------------
 
-Blop provides a default acquisition plan (:func:`blop.plans.default_acquire`) that handle data acquisition. This plan:
+Blop provides a default acquisition plan (:func:`blop.plans.default_acquire`) that handles data acquisition. This plan:
 
 - Uses the **"primary" stream** to store all acquired data
-- Includes a default metadata key **blop_suggestions** which contains all of the suggestions (and their identifiers)
+- Includes **blop_acquisition_order** metadata containing suggestion IDs in acquired row order
+- Includes **blop_suggestions** metadata containing the routed suggestions for backwards compatibility
 
-When a custom acquisition plan is used, how the data is stored depends on the plan implementation. 
+When a custom acquisition plan is used, how the data is stored depends on the plan implementation.
 
 Creating an Evaluation Function
 --------------------------------
@@ -124,13 +125,15 @@ Here's an example evaluation function that reads data from Tiled for where all d
             if not isinstance(uid, str):
                 raise TypeError(f"TiledEvaluation requires a Bluesky run UID string, got {uid!r}")
             run = self.tiled_client[uid]
-            
+            acquisition_order = run.start["blop_acquisition_order"]
+            suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
+
             # Extract data columns
             motor_x_data = run["primary/motor_x"].read()
             outcomes = []
-            for suggestion in suggestions:
-                suggestion_id = suggestion["_id"]
-                motor_x = motor_x_data[suggestion_id % len(motor_x_data)]
+            for index, suggestion_id in enumerate(acquisition_order):
+                suggestion = suggestions_by_id[suggestion_id]
+                motor_x = motor_x_data[index]
                 outcome = {
                     "_id": suggestion["_id"],
                     "objective1": 0.1 * motor_x,

--- a/docs/source/how-to-guides/use-tiled.rst
+++ b/docs/source/how-to-guides/use-tiled.rst
@@ -92,8 +92,12 @@ Data Storage with Blop's Default Plans
 Blop provides a default acquisition plan (:func:`blop.plans.default_acquire`) that handles data acquisition. This plan:
 
 - Uses the **"primary" stream** to store all acquired data
-- Includes **blop_acquisition_order** metadata containing suggestion IDs in acquired row order
+- Includes **blop_acquisition_order** metadata containing suggestion IDs in actual acquired-row order
 - Includes **blop_suggestions** metadata containing the routed suggestions for backwards compatibility
+
+The evaluator's ``suggestions`` sequence is optional context. Do not use its
+positions to align primary rows or infer an optimizer generation order; use
+``blop_acquisition_order`` instead.
 
 When a custom acquisition plan is used, how the data is stored depends on the plan implementation.
 
@@ -126,16 +130,15 @@ Here's an example evaluation function that reads data from Tiled for where all d
                 raise TypeError(f"TiledEvaluation requires a Bluesky run UID string, got {uid!r}")
             run = self.tiled_client[uid]
             acquisition_order = run.start["blop_acquisition_order"]
-            suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
 
+            # These IDs, not positions in suggestions, align the primary rows.
             # Extract data columns
             motor_x_data = run["primary/motor_x"].read()
             outcomes = []
             for index, suggestion_id in enumerate(acquisition_order):
-                suggestion = suggestions_by_id[suggestion_id]
                 motor_x = motor_x_data[index]
                 outcome = {
-                    "_id": suggestion["_id"],
+                    "_id": suggestion_id,
                     "objective1": 0.1 * motor_x,
                 }
                 outcomes.append(outcome)

--- a/docs/source/how-to-guides/use-tiled.rst
+++ b/docs/source/how-to-guides/use-tiled.rst
@@ -95,10 +95,6 @@ Blop provides a default acquisition plan (:func:`blop.plans.default_acquire`) th
 - Includes **blop_acquisition_order** metadata containing suggestion IDs in actual acquired-row order
 - Includes **blop_suggestions** metadata containing the routed suggestions for backwards compatibility
 
-The evaluator's ``suggestions`` sequence is optional context. Do not use its
-positions to align primary rows or infer an optimizer generation order; use
-``blop_acquisition_order`` instead.
-
 When a custom acquisition plan is used, how the data is stored depends on the plan implementation.
 
 Creating an Evaluation Function

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -123,7 +123,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Hashable, Mapping, Sequence

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -123,7 +123,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Hashable, Mapping, Sequence
@@ -138,22 +138,15 @@ class Himmelblau2DEvaluation:
         run = self.tiled_client[uid]
         outcomes = []
         acquisition_order = run.start["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
-        print(
-            "[Himmelblau] evaluating suggestions: ",
-            list(suggestions_by_id),
-            " acquired in order: ",
-            acquisition_order,
-        )
+        print("[Himmelblau] evaluating acquired order: ", acquisition_order)
         for index, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             # Himmelblau function: has four global minima where value = 0
-            outcomes.append({"himmelblau_2d": (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2, "_id": suggestion["_id"]})
+            outcomes.append({"himmelblau_2d": (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2, "_id": suggestion_id})
 
         return outcomes
 ```

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -137,23 +137,23 @@ class Himmelblau2DEvaluation:
             raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
         run = self.tiled_client[uid]
         outcomes = []
-        reordered_suggestions = run.start["blop_suggestions"]
+        acquisition_order = run.start["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
         print(
             "[Himmelblau] evaluating suggestions: ",
-            [s["_id"] for s in suggestions],
-            " reordered to: ",
-            [s["_id"] for s in reordered_suggestions],
+            list(suggestions_by_id),
+            " acquired in order: ",
+            acquisition_order,
         )
-        for index, suggestion in enumerate(reordered_suggestions):
-            # Special key to identify a suggestion
-            suggestion_id = suggestion["_id"]
+        for index, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             # Himmelblau function: has four global minima where value = 0
-            outcomes.append({"himmelblau_2d": (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2, "_id": suggestion_id})
+            outcomes.append({"himmelblau_2d": (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2, "_id": suggestion["_id"]})
 
         return outcomes
 ```

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -157,6 +157,8 @@ def default_acquire(suggestions, actuators, sensors, *, md=None):
         plan_args.append(actuator)
         plan_args.append(values)
 
+    # This plan scans the input sequence in order. Plans that reorder points must
+    # construct this ID list after reordering.
     _md = {"blop_suggestions": suggestions, "blop_acquisition_order": [s["_id"] for s in suggestions]}
     if md:
         _md.update(md)
@@ -203,7 +205,7 @@ sensors = ["himmel_det"]
 
 ## Writing the Evaluation Function
 
-The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` matching the suggestion.
+The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This evaluator uses `blop_acquisition_order` to align detector values with their IDs. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` from that acquisition order.
 
 Because the agent and the ZMQ-Tiled bridge are separate subscribers to the same ZMQ stream, there is a race condition: the agent may receive the stop document before the bridge has finished writing data to Tiled. The evaluation function should poll Tiled until both the run and the detector data are available.
 
@@ -257,12 +259,10 @@ class HimmelblauEvaluation:
         himmel_values = self._wait_for_detector_data(run, "primary/himmel_det")
 
         acquisition_order = run.metadata["start"]["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         outcomes = []
         for idx, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             outcomes.append({
-                "_id": suggestion["_id"],
+                "_id": suggestion_id,
                 "himmelblau": float(himmel_values[idx]),
             })
 

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -205,7 +205,7 @@ sensors = ["himmel_det"]
 
 ## Writing the Evaluation Function
 
-The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This evaluator uses `blop_acquisition_order` to align detector values with their IDs. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` from that acquisition order.
+The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. This evaluator uses `blop_acquisition_order` to align detector values with their IDs. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` from that acquisition order.
 
 Because the agent and the ZMQ-Tiled bridge are separate subscribers to the same ZMQ stream, there is a race condition: the agent may receive the stop document before the bridge has finished writing data to Tiled. The evaluation function should poll Tiled until both the run and the detector data are available.
 

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -157,7 +157,7 @@ def default_acquire(suggestions, actuators, sensors, *, md=None):
         plan_args.append(actuator)
         plan_args.append(values)
 
-    _md = {"blop_suggestions": suggestions}
+    _md = {"blop_suggestions": suggestions, "blop_acquisition_order": [s["_id"] for s in suggestions]}
     if md:
         _md.update(md)
 
@@ -256,8 +256,11 @@ class HimmelblauEvaluation:
         # Read the detector values from the primary data stream
         himmel_values = self._wait_for_detector_data(run, "primary/himmel_det")
 
+        acquisition_order = run.metadata["start"]["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         outcomes = []
-        for idx, suggestion in enumerate(suggestions):
+        for idx, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             outcomes.append({
                 "_id": suggestion["_id"],
                 "himmelblau": float(himmel_values[idx]),

--- a/docs/source/tutorials/queueserver/startup.py
+++ b/docs/source/tutorials/queueserver/startup.py
@@ -65,7 +65,7 @@ def default_acquire(suggestions, actuators, sensors, *, md=None):
         plan_args.append(actuator)
         plan_args.append(values)
 
-    _md = {"blop_suggestions": suggestions}
+    _md = {"blop_suggestions": suggestions, "blop_acquisition_order": [s["_id"] for s in suggestions]}
     if md:
         _md.update(md)
 

--- a/docs/source/tutorials/queueserver/startup.py
+++ b/docs/source/tutorials/queueserver/startup.py
@@ -65,6 +65,8 @@ def default_acquire(suggestions, actuators, sensors, *, md=None):
         plan_args.append(actuator)
         plan_args.append(values)
 
+    # This plan scans the input sequence in order. Plans that reorder points must
+    # construct this ID list after reordering.
     _md = {"blop_suggestions": suggestions, "blop_acquisition_order": [s["_id"] for s in suggestions]}
     if md:
         _md.update(md)

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -115,7 +115,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Hashable, Mapping, Sequence

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -115,7 +115,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
+The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. Suggestions are optional analysis context; do not assume their sequence matches acquired data or preserves optimizer generation order. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Hashable, Mapping, Sequence
@@ -130,19 +130,17 @@ class Himmelblau2DEvaluation():
         run = self.tiled_client[uid]
         outcomes = []
         acquisition_order = run.start["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
-        print("[Himmelblau] evaluating suggestions: ", list(suggestions_by_id), " acquired in order: ", acquisition_order)
+        print("[Himmelblau] evaluating acquired order: ", acquisition_order)
         for index, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             # Himmelblau function: has four global minima where value = 0
             outcomes.append({
                 "himmelblau_2d": (x1 ** 2 + x2 - 11) ** 2 + (x1 + x2 ** 2 - 7) ** 2,
-                "_id": suggestion["_id"]
+                "_id": suggestion_id
             })
         
         return outcomes

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -129,20 +129,20 @@ class Himmelblau2DEvaluation():
             raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
         run = self.tiled_client[uid]
         outcomes = []
-        reordered_suggestions = run.start["blop_suggestions"]
+        acquisition_order = run.start["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
-        print("[Himmelblau] evaluating suggestions: ", [s["_id"] for s in suggestions], " reordered to: ", [s["_id"] for s in reordered_suggestions])
-        for index, suggestion in enumerate(reordered_suggestions):
-            # Special key to identify a suggestion
-            suggestion_id = suggestion["_id"]
+        print("[Himmelblau] evaluating suggestions: ", list(suggestions_by_id), " acquired in order: ", acquisition_order)
+        for index, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             # Himmelblau function: has four global minima where value = 0
             outcomes.append({
                 "himmelblau_2d": (x1 ** 2 + x2 - 11) ** 2 + (x1 + x2 ** 2 - 7) ** 2,
-                "_id": suggestion_id
+                "_id": suggestion["_id"]
             })
         
         return outcomes

--- a/docs/source/tutorials/xrt-demo.md
+++ b/docs/source/tutorials/xrt-demo.md
@@ -201,16 +201,18 @@ class DetectorEvaluation(EvaluationFunction):
         # Read beam images from detector
         images = run[f"primary/{screen.name}"].read()
 
-        # Suggestion IDs stored in start document metadata
-        suggestion_ids = [suggestion["_id"] for suggestion in run.metadata["start"]["blop_suggestions"]]
+        # Match acquired images to the original suggestions by ID
+        acquisition_order = run.metadata["start"]["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
 
         # Compute statistics from each image
-        for idx, sid in enumerate(suggestion_ids):
+        for idx, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             image = images[idx]
             fwhm, intensity = self._compute_stats(image)
 
             outcome = {
-                "_id": sid,
+                "_id": suggestion["_id"],
                 "fwhm": fwhm,
                 # "intensity": intensity,
             }

--- a/docs/source/tutorials/xrt-demo.md
+++ b/docs/source/tutorials/xrt-demo.md
@@ -201,18 +201,16 @@ class DetectorEvaluation(EvaluationFunction):
         # Read beam images from detector
         images = run[f"primary/{screen.name}"].read()
 
-        # Match acquired images to the original suggestions by ID
+        # These IDs, not positions in suggestions, are ordered to match acquired images.
         acquisition_order = run.metadata["start"]["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
 
         # Compute statistics from each image
         for idx, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             image = images[idx]
             fwhm, intensity = self._compute_stats(image)
 
             outcome = {
-                "_id": suggestion["_id"],
+                "_id": suggestion_id,
                 "fwhm": fwhm,
                 # "intensity": intensity,
             }

--- a/docs/source/tutorials/xrt-kb-mirrors.md
+++ b/docs/source/tutorials/xrt-kb-mirrors.md
@@ -231,16 +231,18 @@ class DetectorEvaluation(EvaluationFunction):
         # Read beam images from detector
         images = run["primary/det_image"].read()
 
-        # Suggestion IDs stored in start document metadata
-        suggestion_ids = [suggestion["_id"] for suggestion in run.metadata["start"]["blop_suggestions"]]
+        # Match acquired images to the original suggestions by ID
+        acquisition_order = run.metadata["start"]["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
 
         # Compute statistics from each image
-        for idx, sid in enumerate(suggestion_ids):
+        for idx, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             image = images[idx]
             fwhm, intensity = self._compute_stats(image)
 
             outcome = {
-                "_id": sid,
+                "_id": suggestion["_id"],
                 "fwhm": fwhm,
                 "intensity": intensity,
             }

--- a/docs/source/tutorials/xrt-kb-mirrors.md
+++ b/docs/source/tutorials/xrt-kb-mirrors.md
@@ -231,18 +231,16 @@ class DetectorEvaluation(EvaluationFunction):
         # Read beam images from detector
         images = run["primary/det_image"].read()
 
-        # Match acquired images to the original suggestions by ID
+        # These IDs, not positions in suggestions, are ordered to match acquired images.
         acquisition_order = run.metadata["start"]["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
 
         # Compute statistics from each image
         for idx, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             image = images[idx]
             fwhm, intensity = self._compute_stats(image)
 
             outcome = {
-                "_id": suggestion["_id"],
+                "_id": suggestion_id,
                 "fwhm": fwhm,
                 "intensity": intensity,
             }

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -54,7 +54,8 @@ def default_acquire(
     Acquire data for optimization. Simply a list scan.
 
     Includes ``"blop_suggestions"`` metadata containing the routed suggestions for
-    backwards compatibility and ``"blop_acquisition_order"`` containing their IDs in scan order.
+    backwards compatibility and ``"blop_acquisition_order"`` containing IDs in actual scan order.
+    Use those IDs, rather than positions in ``suggestions``, to associate acquired rows.
 
     Parameters
     ----------

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -53,15 +53,15 @@ def default_acquire(
     """
     Acquire data for optimization. Simply a list scan.
 
-    Includes a default metadata key "blop_suggestions" which can be used to identify
-    the suggestions that were acquired for each step of the scan.
+    Includes ``"blop_suggestions"`` metadata containing the routed suggestions for
+    backwards compatibility and ``"blop_acquisition_order"`` containing their IDs in scan order.
 
     Parameters
     ----------
     suggestions: Sequence[Mapping]
         A sequence of mappings, each containing the parameterization of a point to evaluate.
-        The "_id" key is optional and can be used to identify each suggestion. It is suggested
-        to add "_id" values to the run metadata for later identification of the acquired data.
+        Each mapping must contain a unique ``"_id"`` key used to associate the acquired
+        data with its suggestion.
     actuators: Sequence[Actuator]
         The actuators to move and the inputs to move them to.
     sensors: Sequence[Sensor]
@@ -96,7 +96,13 @@ def default_acquire(
         suggestions = route_suggestions(suggestions, starting_position=current_position)
 
     run_md = dict(md or {})
-    run_md.update({"blop_suggestions": suggestions, "run_key": _DEFAULT_ACQUIRE_RUN_KEY})
+    run_md.update(
+        {
+            "blop_suggestions": suggestions,
+            "blop_acquisition_order": [suggestion[ID_KEY] for suggestion in suggestions],
+            "run_key": _DEFAULT_ACQUIRE_RUN_KEY,
+        }
+    )
     plan_args = _unpack_for_list_scan(suggestions, actuators)
     return (
         # TODO: fix argument type in bluesky.plans.list_scan

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -198,8 +198,9 @@ class EvaluationFunction(Protocol):
     Notes
     -----
     The evaluation function is called after data acquisition to compute outcomes.
-    It uses the acquisition identifier returned by the acquisition plan to retrieve
-    the relevant data and computes objective values and metrics for each suggestion.
+    Use the acquisition identifier to retrieve data and associate each row with a
+    suggestion by its ``"_id"``. The order of ``suggestions`` is not an
+    acquisition-order or optimizer-order contract.
 
     Examples
     --------
@@ -217,14 +218,16 @@ class EvaluationFunction(Protocol):
             The acquisition identifier returned by the acquisition plan. This may be a Bluesky run UID,
             a tuple of event UIDs, or another hashable lookup key.
         suggestions: Sequence[Mapping]
-            A sequence of mappings, each containing the parameterization of a point to evaluate.
-            The "_id" key is optional and can be used to identify each suggestion.
+            A sequence of mappings, each containing a parameterization to evaluate.
+            Each mapping must contain a unique ``"_id"``. Do not assume its order
+            aligns with acquired data or preserves optimizer generation order.
 
         Returns
         -------
         Sequence[Mapping]
-            A sequence of mappings containing the outcomes of the acquisition, one for each suggested parameterization.
-            The "_id" key is optional and can be used to identify each outcome.
+            A sequence of mappings containing the outcomes of the acquisition, one for each
+            suggested parameterization. Each mapping must contain an ``"_id"`` identifying
+            its evaluated suggestion.
         """
         ...
 
@@ -249,6 +252,7 @@ class AcquisitionPlan(Protocol):
     The acquisition plan is a Bluesky plan that should move the actuators to each
     suggested position, acquire data from the sensors, and return a hashable
     identifier that the evaluation function can use to retrieve the acquired data.
+    When it may reorder points, it must record their IDs in actual acquisition order.
     """
 
     @plan
@@ -262,17 +266,17 @@ class AcquisitionPlan(Protocol):
         """
         Acquire data for optimization.
 
-        This should be a Bluesky plan that moves the actuators to each of their suggested positions
-        and acquires data from the sensors. Suggestions may be re-ordered for more efficient acquisition
-        but it is the responsibility of the implementer to ensure fetching the data during
-        evaluation is feasible.
+        This should be a Bluesky plan that moves the actuators to each suggested position
+        and acquires data from the sensors. Its input sequence is not an acquisition-order
+        contract. If it records data in a different order, it must store each row's
+        ``"_id"`` in actual acquisition order (for example, under ``"blop_acquisition_order"``).
 
         Parameters
         ----------
         suggestions: Sequence[Mapping]
-            A sequence of mappings, each containing the parameterization of a point to evaluate.
-            The "_id" key is optional and can be used to identify each suggestion. It is suggested
-            to add "_id" values to the run metadata for later identification of the acquired data.
+            A sequence of mappings, each containing a parameterization to evaluate.
+            Each mapping must contain a unique ``"_id"``. Do not assume its order
+            matches acquisition order or preserves optimizer generation order.
         actuators: Sequence[Actuator]
             The actuators to move to their suggested positions.
         sensors: Sequence[Sensor], optional

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -200,8 +200,7 @@ class EvaluationFunction(Protocol):
     -----
     The evaluation function is called after data acquisition to compute outcomes.
     Use the acquisition identifier to retrieve data and associate each row with a
-    suggestion by its ``"_id"``. The order of ``suggestions`` is not an
-    acquisition-order or optimizer-order contract.
+    suggestion by its ``"_id"``.
 
     Examples
     --------

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -443,6 +443,7 @@ class QueueserverOptimizationRunner:
         md: dict[str, Any] = {
             CORRELATION_UID_KEY: self._state.current_uid,
             "blop_suggestions": self._state.current_suggestions,
+            "blop_acquisition_order": [suggestion[ID_KEY] for suggestion in self._state.current_suggestions],
         }
 
         return BPlan(

--- a/src/blop/queueserver.py
+++ b/src/blop/queueserver.py
@@ -443,7 +443,6 @@ class QueueserverOptimizationRunner:
         md: dict[str, Any] = {
             CORRELATION_UID_KEY: self._state.current_uid,
             "blop_suggestions": self._state.current_suggestions,
-            "blop_acquisition_order": [suggestion[ID_KEY] for suggestion in self._state.current_suggestions],
         }
 
         return BPlan(

--- a/src/blop/tests/integration/test_simple_experiment.py
+++ b/src/blop/tests/integration/test_simple_experiment.py
@@ -25,19 +25,15 @@ class HimmelblauEvaluation:
         self.uids.append(uid)
         run = self.tiled_client[uid]
         acquisition_order = run.start["blop_acquisition_order"]
-        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
-        assert set(acquisition_order) == set(suggestions_by_id)
-
         outcomes = []
         for index, suggestion_id in enumerate(acquisition_order):
-            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             value = (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2
-            outcomes.append({"_id": suggestion["_id"], "himmelblau_2d": value})
+            outcomes.append({"_id": suggestion_id, "himmelblau_2d": value})
 
         self.outcomes.extend(outcomes)
         return outcomes

--- a/src/blop/tests/integration/test_simple_experiment.py
+++ b/src/blop/tests/integration/test_simple_experiment.py
@@ -24,16 +24,16 @@ class HimmelblauEvaluation:
     def __call__(self, uid: str, suggestions: list[dict]) -> list[dict]:
         self.uids.append(uid)
         run = self.tiled_client[uid]
-        reordered_suggestions = run.start["blop_suggestions"]
+        acquisition_order = run.start["blop_acquisition_order"]
+        suggestions_by_id = {suggestion["_id"]: suggestion for suggestion in suggestions}
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
-        assert {suggestion["_id"] for suggestion in reordered_suggestions} == {
-            suggestion["_id"] for suggestion in suggestions
-        }
+        assert set(acquisition_order) == set(suggestions_by_id)
 
         outcomes = []
-        for index, suggestion in enumerate(reordered_suggestions):
+        for index, suggestion_id in enumerate(acquisition_order):
+            suggestion = suggestions_by_id[suggestion_id]
             x1 = x1_data[index]
             x2 = x2_data[index]
             value = (x1**2 + x2 - 11) ** 2 + (x1 + x2**2 - 7) ** 2

--- a/src/blop/tests/integration/test_simple_experiment.py
+++ b/src/blop/tests/integration/test_simple_experiment.py
@@ -28,6 +28,8 @@ class HimmelblauEvaluation:
         x1_data = run["primary/x1"].read()
         x2_data = run["primary/x2"].read()
 
+        assert set(acquisition_order) == {suggestion["_id"] for suggestion in suggestions}
+
         outcomes = []
         for index, suggestion_id in enumerate(acquisition_order):
             x1 = x1_data[index]

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -522,7 +522,7 @@ def test_default_acquire_merges_metadata(RE):
 
 
 def test_default_acquire_records_acquisition_order(RE):
-    """Store suggestion IDs in the order used by the scan."""
+    """Record IDs in scan order rather than incoming suggestion order."""
     movable = MovableSignal("x1", initial_value=-1.0)
     readable = ReadableSignal("objective")
     suggestions = [{"x1": 10.0, "_id": "far"}, {"x1": 0.0, "_id": "near"}]

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -521,6 +521,28 @@ def test_default_acquire_merges_metadata(RE):
     assert start_docs[0]["run_key"] == "default_acquire"
 
 
+def test_default_acquire_records_acquisition_order(RE):
+    """Store suggestion IDs in the order used by the scan."""
+    movable = MovableSignal("x1", initial_value=-1.0)
+    readable = ReadableSignal("objective")
+    suggestions = [{"x1": 10.0, "_id": "far"}, {"x1": 0.0, "_id": "near"}]
+    start_docs = []
+
+    def callback(name, doc):
+        if name == "start":
+            start_docs.append(doc)
+
+    RE.subscribe(callback)
+    try:
+        RE(default_acquire(suggestions, [movable], [readable]))
+    finally:
+        RE.unsubscribe(callback)
+
+    assert len(start_docs) == 1
+    assert start_docs[0]["blop_suggestions"] == [suggestions[1], suggestions[0]]
+    assert start_docs[0]["blop_acquisition_order"] == ["near", "far"]
+
+
 def test_default_acquire_multiple_movables_readables(RE):
     """Test with multiple movables, positions, and readables."""
     movable1 = MovableSignal("x1", initial_value=-1.0)

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -285,6 +285,20 @@ def test_runner_run_submits_suggestions_to_queueserver():
     assert not future.done()
 
 
+def test_runner_includes_acquisition_order_metadata(mock_optimization_problem):
+    """Submit suggestion IDs in the acquisition plan metadata."""
+    mock_client = MagicMock(spec=QueueserverClient)
+    runner = QueueserverOptimizationRunner(
+        optimization_problem=mock_optimization_problem,
+        queueserver_client=mock_client,
+    )
+
+    runner.run(iterations=1, num_points=1)
+    submitted_plan = mock_client.submit_plan.call_args[0][0]
+    assert submitted_plan.kwargs["md"]["blop_suggestions"] == mock_optimization_problem.optimizer.suggest.return_value
+    assert submitted_plan.kwargs["md"]["blop_acquisition_order"] == [0]
+
+
 def test_runner_run_passes_acquisition_plan_kwargs_to_bplan():
     """Test that acquisition_plan_kwargs are forwarded to the submitted BPlan."""
     mock_client = MagicMock(spec=QueueserverClient)

--- a/src/blop/tests/test_queueserver.py
+++ b/src/blop/tests/test_queueserver.py
@@ -285,8 +285,8 @@ def test_runner_run_submits_suggestions_to_queueserver():
     assert not future.done()
 
 
-def test_runner_includes_acquisition_order_metadata(mock_optimization_problem):
-    """Submit suggestion IDs in the acquisition plan metadata."""
+def test_runner_leaves_acquisition_order_metadata_to_plan(mock_optimization_problem):
+    """Let the plan that executes acquisition record its actual order."""
     mock_client = MagicMock(spec=QueueserverClient)
     runner = QueueserverOptimizationRunner(
         optimization_problem=mock_optimization_problem,
@@ -296,7 +296,7 @@ def test_runner_includes_acquisition_order_metadata(mock_optimization_problem):
     runner.run(iterations=1, num_points=1)
     submitted_plan = mock_client.submit_plan.call_args[0][0]
     assert submitted_plan.kwargs["md"]["blop_suggestions"] == mock_optimization_problem.optimizer.suggest.return_value
-    assert submitted_plan.kwargs["md"]["blop_acquisition_order"] == [0]
+    assert "blop_acquisition_order" not in submitted_plan.kwargs["md"]
 
 
 def test_runner_run_passes_acquisition_plan_kwargs_to_bplan():


### PR DESCRIPTION
Assisted-by: oh-my-pi:gpt-5.5

To be used in favor of `blop_suggestions` in evaluation functions. The intent is clearer.

Closes #352 