### PR TITLE
Remove `experiment_type` from agent initialization

### DIFF
--- a/docs/source/tutorials/xrt-demo.md
+++ b/docs/source/tutorials/xrt-demo.md
@@ -226,7 +226,6 @@ agent = Agent(
     evaluation_function=DetectorEvaluation(tiled_client),
     name="xrt-blop-demo",
     description="A demo of the Blop agent with XRT simulated beamline",
-    experiment_type="demo",
 )
 ```
 

--- a/docs/source/tutorials/xrt-kb-mirrors.md
+++ b/docs/source/tutorials/xrt-kb-mirrors.md
@@ -275,7 +275,6 @@ agent = Agent(
     outcome_constraints=outcome_constraints,
     name="xrt-blop-demo",
     description="A demo of the Blop agent with XRT simulated beamline",
-    experiment_type="demo",
 )
 
 # Register intensity as a tracking metric (monitored but not optimized)


### PR DESCRIPTION
In tutorials that use Ax, the `experiment_type` argument is provided during `Agent` initialization, which causes an error readout. This argument is only useful if you're taking advantage of Ax's storage capabilities, for which the tutorials are not.