### PR TITLE
Make EvauationFunction uid argument a generic type

### DIFF
--- a/docs/source/explanations/acquisition-plan.rst
+++ b/docs/source/explanations/acquisition-plan.rst
@@ -25,18 +25,18 @@ association between optimizer suggestions and the acquired data within the
 chosen storage or event system (typically stashing the suggestions in proper 
 order in storage or tagging the run markdown).
 
-The plan must return a hashable acquisition identifier. Blop passes that value
-unchanged to the evaluation function. A Bluesky run UID is the usual identifier
-for run-owning acquisitions. The in-run default returns suggestion IDs in the
-order they were executed, but custom plans may return any hashable key their
-matching evaluation function understands.
+The plan must return a uid. Blop passes that value unchanged to the evaluation
+function. A Bluesky run UID is the usual value for run-owning acquisitions. The
+in-run default returns suggestion IDs in the order they were executed, but
+custom plans may return any concrete uid type their matching evaluation
+function understands.
 
 A simple example that optimizes in a subspace while executing measurements in
 the full physical coordinate system is shown below. 
 
 .. code-block:: python
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
     from typing import Any
 
     from bluesky.utils import MsgGenerator
@@ -49,7 +49,7 @@ the full physical coordinate system is shown below.
             actuators: Sequence[Actuator],
             sensors: Sequence[Sensor] | None = None,
             md: Mapping[str, Any] | None = None,
-        ) -> MsgGenerator[Hashable]:
+        ) -> MsgGenerator[str]:
 
             coords = [subspace_to_real(s) for s in suggestions]
             return (yield from default_acquire(

--- a/docs/source/explanations/callbacks.rst
+++ b/docs/source/explanations/callbacks.rst
@@ -54,9 +54,9 @@ but the contents are optimization-focused.
     values, and outcome values. For batched optimization, these values may be
     arrays.
 
-For ``acquisition_uid``, native array-like identifiers such as a tuple of event
-UIDs are stored directly. Other hashable identifiers are stored using their
-``repr``; the evaluation function still receives the original identifier.
+For ``acquisition_uid``, native array-like UIDs are stored directly. Mapping and
+dataclass UIDs that serialize to JSON are stored as dictionaries. Other UIDs are
+stored using their ``repr``; the evaluation function still receives the original value.
 
 ``stop``
     Completion status and reason, useful for summaries or cleanup.

--- a/docs/source/explanations/callbacks.rst
+++ b/docs/source/explanations/callbacks.rst
@@ -54,8 +54,7 @@ but the contents are optimization-focused.
     values, and outcome values. For batched optimization, these values may be
     arrays.
 
-For ``acquisition_uid``, native array-like UIDs are stored directly. Mapping and
-dataclass UIDs that serialize to JSON are stored as JSON strings. Other UIDs are
+For ``acquisition_uid``, native array-like UIDs are stored directly. Other UIDs are
 stored using their ``repr``; the evaluation function still receives the original value.
 
 ``stop``

--- a/docs/source/explanations/callbacks.rst
+++ b/docs/source/explanations/callbacks.rst
@@ -55,7 +55,7 @@ but the contents are optimization-focused.
     arrays.
 
 For ``acquisition_uid``, native array-like UIDs are stored directly. Mapping and
-dataclass UIDs that serialize to JSON are stored as dictionaries. Other UIDs are
+dataclass UIDs that serialize to JSON are stored as JSON strings. Other UIDs are
 stored using their ``repr``; the evaluation function still receives the original value.
 
 ``stop``

--- a/docs/source/explanations/evaluation-function.rst
+++ b/docs/source/explanations/evaluation-function.rst
@@ -4,45 +4,44 @@ The Evaluation Function
 The evaluation function is the primary interface between **blop** and your experimental data analysis pipeline. It is responsible for retrieving
 experimental data, performing any required post-processing, and computing the objective values returned to the optimizer.
 
-Rather than prescribing a particular processing framework or directly managing data, **blop** uses an identifier-driven workflow. The acquisition
-plan returns a hashable identifier, and Blop passes that same identifier to the evaluation function. This mirrors event-based processing patterns
-commonly used at beamlines while also supporting data acquired within a single Bluesky run.
+Rather than prescribing a particular processing framework or directly managing data, **blop** uses a uid-driven workflow. The acquisition
+plan returns a uid, and Blop passes that same value to the evaluation function. The uid must uniquely identify the acquisition.
 
 
 Anatomy of an Evaluation Function
 ---------------------------------
 
-An evaluation function is a callable that accepts a hashable acquisition identifier and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The identifier may be a Bluesky run UID, suggestion IDs in executed order, a tuple of event UIDs, or another hashable key understood by the evaluator. The suggestion sequence is optimizer-provided and is not guaranteed to be in acquisition order; match data and outcomes by ``_id``.
+An evaluation function is a callable that accepts a uid and a sequence of suggestion mappings, then returns a sequence of outcome mappings. The uid may be a Bluesky run UID, suggestion IDs in executed order, a tuple of event UIDs, or a backend-specific type understood by the evaluator. The suggestion sequence is optimizer-provided and is not guaranteed to be in acquisition order; match data and outcomes by ``_id``.
 
-A typical implementation is shown below:
+A run-owning acquisition plan usually returns a string run UID:
 
 .. code-block:: python
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
-    class GenericEvaluation(EvaluationFunction):
-        """Inheriting from EvaluationFunction is optional but provides
-        a useful typing protocol."""
+    from blop.protocols import EvaluationFunction
 
-        def __init__(self, **meta_parameters):
-            # Perform one-time setup before passing the evaluator to
-            # the optimizer.
-            #
-            # Typical responsibilities include:
-            #   - stashing storage clients within self (e.g. Tiled)
-            #   - Initializing analysis resources (dask distributed is considered but yet unexplored in our support)
-            #   - Configuring optimization-specific parameters 
-            #       - (perhaps varying of exponents in loss combinations, selecting between L1 and L2 norm...)
+    class RunUidEvaluation(EvaluationFunction[str]):
+        """Evaluator for acquisition plans that return Bluesky run UID strings."""
 
-        def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-            # Invoked with the identifier returned by the acquisition plan.
-            #
-            # Typical responsibilities include:
-            #   - Retrieving the data associated with the identifier
-            #   - Iterating over individual suggestions in the acquisition
-            #       - using the acquisition plan's documented order/correlation key
-            #   - Constructing a per-suggestion analysis context
-            #   - Calling a lower-level objective function for each sample or suggestion
+        def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+            run = self.tiled_client[uid]
+            return analyze_run(run, suggestions)
+
+For a custom plan that returns a richer UID, use that concrete type in both the plan and evaluator:
+
+.. code-block:: python
+
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class QueueAcquisitionUID:
+        correlation_uid: str
+        item_uid: str | None
+
+    class QueueEvaluation(EvaluationFunction[QueueAcquisitionUID]):
+        def __call__(self, uid: QueueAcquisitionUID, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+            return analyze_queue_data(uid, suggestions)
 
 Although the interface is intentionally minimal, separating setup from
 execution is recommended.
@@ -52,7 +51,7 @@ execution is recommended.
     loading analysis resources, and configuring reusable analysis parameters.
 
 ``__call__``
-    Retrieve the data associated with the acquisition identifier, iterate over the
+    Retrieve the data associated with the uid, iterate over the
     individual suggestions or samples, and orchestrate the analysis workflow.
 
 Where possible, keep the actual objective calculation in a separate function

--- a/docs/source/explanations/protocols.rst
+++ b/docs/source/explanations/protocols.rst
@@ -21,8 +21,8 @@ Data Flow
 The data flow for a typical optimization workflow is as follows:
 
 1. The optimizer suggests a sequence of mappings describing points to evaluate. When suggestions include ``_id`` values used by Blop optimization plans, those values must be unique within a batch and hashable.
-2. The acquisition plan acquires data and returns a hashable acquisition identifier.
-3. Blop passes that identifier unchanged to the evaluation function, which transforms the acquired data into a sequence of outcome mappings. The suggestion sequence passed to the evaluator is optimizer-provided, not necessarily acquisition-ordered.
+2. The acquisition plan acquires data and returns a uid.
+3. Blop passes that uid unchanged to the evaluation function, which transforms the acquired data into a sequence of outcome mappings. The suggestion sequence passed to the evaluator is optimizer-provided, not necessarily acquisition-ordered.
 4. The optimizer ingests the outcomes to inform future suggestions.
 
 .. image:: ../_static/protocol-data-flow.png

--- a/docs/source/how-to-guides/acquire-baseline.rst
+++ b/docs/source/how-to-guides/acquire-baseline.rst
@@ -99,7 +99,7 @@ Here we configure an agent with three DOFs and two objectives. The second object
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from blop.ax import Agent, RangeDOF, Objective, OutcomeConstraint
 
@@ -116,7 +116,7 @@ Here we configure an agent with three DOFs and two objectives. The second object
 
     outcome_constraints = [OutcomeConstraint("x >= baseline", x=objectives[1])]
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/attach-data-to-experiments.rst
+++ b/docs/source/how-to-guides/attach-data-to-experiments.rst
@@ -104,7 +104,7 @@ The ``DOF`` and ``Objective`` names must match the keys in the data dictionaries
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from blop.ax import Agent, RangeDOF, Objective
 
@@ -119,7 +119,7 @@ The ``DOF`` and ``Objective`` names must match the keys in the data dictionaries
         Objective(name="objective2", minimize=False),
     ]
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/custom-callbacks.rst
+++ b/docs/source/how-to-guides/custom-callbacks.rst
@@ -65,9 +65,9 @@
     motor_x = MovableSignal("motor_x")
     signal = ReadableSignal("signal")
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         outcomes = []
         for suggestion in suggestions:
             outcomes.append({

--- a/docs/source/how-to-guides/custom-generation-strategies.rst
+++ b/docs/source/how-to-guides/custom-generation-strategies.rst
@@ -97,7 +97,7 @@ Configure an agent
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from blop.ax import Agent, RangeDOF, Objective
 
@@ -110,7 +110,7 @@ Configure an agent
         Objective(name="objective1", minimize=False),
     ]
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/manual-suggestions.rst
+++ b/docs/source/how-to-guides/manual-suggestions.rst
@@ -70,10 +70,10 @@
     motor_x = MovableSignal("motor_x")
     motor_y = MovableSignal("motor_y")
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     # Mock evaluation function for examples
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Mock evaluation function that returns constant outcomes."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/set-dof-constraints.rst
+++ b/docs/source/how-to-guides/set-dof-constraints.rst
@@ -77,7 +77,7 @@ Create DOFs and an objective
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from blop.ax import RangeDOF, Objective
 
@@ -91,7 +91,7 @@ Create DOFs and an objective
 
     objective = Objective(name="objective1", minimize=False)
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/set-outcome-constraints.rst
+++ b/docs/source/how-to-guides/set-outcome-constraints.rst
@@ -84,7 +84,7 @@ Create DOFs and multiple objectives
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from blop.ax import RangeDOF, Objective
 
@@ -104,7 +104,7 @@ Create DOFs and multiple objectives
         Objective(name="objective2", minimize=False),
     ]
 
-    def evaluation_function(uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def evaluation_function(uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """Replace this with your own evaluation function."""
         outcomes = []
         for suggestion in suggestions:

--- a/docs/source/how-to-guides/use-ophyd-devices.rst
+++ b/docs/source/how-to-guides/use-ophyd-devices.rst
@@ -58,7 +58,7 @@ If you use a custom acquisition plan by implementing the :class:`blop.protocols.
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
     from typing import Any
 
     import bluesky.plan_stubs as bps
@@ -74,7 +74,7 @@ If you use a custom acquisition plan by implementing the :class:`blop.protocols.
         actuators: Sequence[Actuator],
         sensors: Sequence[Sensor] | None = None,
         md: Mapping[str, Any] | None = None,
-    ) -> MsgGenerator[Hashable]:
+    ) -> MsgGenerator[str]:
         assert actuators[0].name == "signal1"
         assert sensors is not None
         assert sensors[0].name == "signal2"

--- a/docs/source/how-to-guides/use-tiled.rst
+++ b/docs/source/how-to-guides/use-tiled.rst
@@ -102,7 +102,7 @@ Creating an Evaluation Function
 To access data from Tiled within your evaluation function, create a class that:
 
 1. Accepts a client instance in its ``__init__`` method
-2. Accepts the hashable acquisition identifier and validates that this default-acquisition example received a string run UID
+2. Accepts the string uid returned by the default acquisition plan
 3. Processes the data to compute optimization objectives
 
 Evaluation Function with Tiled
@@ -112,7 +112,7 @@ Here's an example evaluation function that reads data from Tiled for where all d
 
 .. testcode::
 
-    from collections.abc import Hashable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
 
     from tiled.client.container import Container
 
@@ -120,11 +120,9 @@ Here's an example evaluation function that reads data from Tiled for where all d
         def __init__(self, tiled_client: Container):
             self.tiled_client = tiled_client
 
-        def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-            if not isinstance(uid, str):
-                raise TypeError(f"TiledEvaluation requires a Bluesky run UID string, got {uid!r}")
+        def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
             run = self.tiled_client[uid]
-            
+
             # Extract data columns
             motor_x_data = run["primary/motor_x"].read()
             outcomes = []

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,15 @@
 Release History
 ===============
 
+Unreleased
+----------
+
+Compatibility Notes
+...................
+* ``EvaluationFunction`` and ``AcquisitionPlan`` are now generic over the uid type, allowing
+  evaluators to accept richer backend-specific objects without requiring them to be hashable
+  (`#369 <https://github.com/bluesky/blop/issues/369>`_).
+
 v1.1.0 (2026-08-26)
 -------------------
 

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -123,18 +123,16 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
+The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID.
 
 ```{code-cell} ipython3
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 class Himmelblau2DEvaluation:
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-        if not isinstance(uid, str):
-            raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
+    def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         run = self.tiled_client[uid]
         outcomes = []
         reordered_suggestions = run.start["blop_suggestions"]

--- a/docs/source/tutorials/gradient-optimization.md
+++ b/docs/source/tutorials/gradient-optimization.md
@@ -123,7 +123,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID and ``blop_acquisition_order`` associates measurements with outcomes.
+The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Mapping, Sequence

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -203,12 +203,12 @@ sensors = ["himmel_det"]
 
 ## Writing the Evaluation Function
 
-The evaluation function is called each time a plan completes. Its general contract accepts a hashable acquisition identifier and a sequence of suggestion mappings, and returns a sequence of outcome mappings. The queueserver runner uses the Bluesky run UID as its acquisition identifier, so this evaluator validates that it received a string before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` matching the suggestion.
+The evaluation function is called each time a plan completes. Its general contract accepts a uid and a sequence of suggestion mappings, and returns a sequence of outcome mappings. The queueserver runner uses the Bluesky run UID, so this evaluator types ``uid`` as ``str`` before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` matching the suggestion.
 
 Because the agent and the ZMQ-Tiled bridge are separate subscribers to the same ZMQ stream, there is a race condition: the agent may receive the stop document before the bridge has finished writing data to Tiled. The evaluation function should poll Tiled until both the run and the detector data are available.
 
 ```{code-cell} ipython3
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 from tiled.client.container import Container
@@ -248,9 +248,7 @@ class HimmelblauEvaluation:
             "The ZMQ-Tiled bridge may still be writing the run."
         )
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-        if not isinstance(uid, str):
-            raise TypeError(f"HimmelblauEvaluation requires a Bluesky run UID string, got {uid!r}")
+    def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         run = self._wait_for_run(uid)
 
         # Read the detector values from the primary data stream

--- a/docs/source/tutorials/queueserver.md
+++ b/docs/source/tutorials/queueserver.md
@@ -205,7 +205,7 @@ sensors = ["himmel_det"]
 
 ## Writing the Evaluation Function
 
-The evaluation function is called each time a plan completes. Its general contract accepts a uid and a sequence of suggestion mappings, and returns a sequence of outcome mappings. This evaluator uses ``blop_acquisition_order`` to align detector values with IDs. The queueserver runner uses the Bluesky run UID, so this evaluator types ``uid`` as ``str`` before looking up the run in Tiled. Each outcome must contain the objective value(s) and an ``_id`` from that acquisition order.
+The evaluation function is called each time a plan completes. Its general contract accepts a uid and a sequence of suggestion mappings, and returns a sequence of outcome mappings. This evaluator uses `blop_acquisition_order` to align detector values with IDs. The queueserver runner uses the Bluesky run UID, so this evaluator types `uid` as `str` before looking up the run in Tiled. Each outcome must contain the objective value(s) and an `_id` from that acquisition order.
 
 Because the agent and the ZMQ-Tiled bridge are separate subscribers to the same ZMQ stream, there is a race condition: the agent may receive the stop document before the bridge has finished writing data to Tiled. The evaluation function should poll Tiled until both the run and the detector data are available.
 

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -115,18 +115,16 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the hashable identifier returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the identifier is a Bluesky run UID.
+The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID.
 
 ```{code-cell} ipython3
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 class Himmelblau2DEvaluation():
     def __init__(self, tiled_client: Container):
         self.tiled_client = tiled_client
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-        if not isinstance(uid, str):
-            raise TypeError(f"Himmelblau2DEvaluation requires a Bluesky run UID string, got {uid!r}")
+    def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         run = self.tiled_client[uid]
         outcomes = []
         reordered_suggestions = run.start["blop_suggestions"]

--- a/docs/source/tutorials/simple-experiment.md
+++ b/docs/source/tutorials/simple-experiment.md
@@ -115,7 +115,7 @@ sensors = []
 
 ## Writing the evaluation function
 
-The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID and ``blop_acquisition_order`` associates measurements with outcomes.
+The **evaluation function** computes objective values from experimental data. Blop passes it the uid returned by the acquisition plan and the suggestions that were tried. This tutorial uses the default acquisition plan, so the uid is a Bluesky run UID and `blop_acquisition_order` associates measurements with outcomes.
 
 ```{code-cell} ipython3
 from collections.abc import Mapping, Sequence

--- a/docs/source/tutorials/xrt-demo.md
+++ b/docs/source/tutorials/xrt-demo.md
@@ -121,7 +121,7 @@ objectives = [
 ```
 
 ```{code-cell} ipython3
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 class DetectorEvaluation(EvaluationFunction):
     def __init__(self, tiled_client: Container):
@@ -192,9 +192,7 @@ class DetectorEvaluation(EvaluationFunction):
 
         return float(fwhm), float(intensity)
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-        if not isinstance(uid, str):
-            raise TypeError(f"DetectorEvaluation requires a Bluesky run UID string, got {uid!r}")
+    def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         outcomes = []
         run = self.tiled_client[uid]
 

--- a/docs/source/tutorials/xrt-kb-mirrors.md
+++ b/docs/source/tutorials/xrt-kb-mirrors.md
@@ -141,9 +141,9 @@ Using a single objective with an outcome constraint gives us the best of both wo
 
 ## Writing an Evaluation Function
 
-The **evaluation function** is the bridge between raw experimental data and the optimizer. After each measurement, the optimizer needs to know how well that configuration performed. The general interface receives a hashable acquisition identifier; this tutorial uses the default acquisition plan, so that identifier is a Bluesky run UID. Our evaluation function:
+The **evaluation function** is the bridge between raw experimental data and the optimizer. After each measurement, the optimizer needs to know how well that configuration performed. The general interface receives a uid; this tutorial uses the default acquisition plan, so that uid is a Bluesky run UID. Our evaluation function:
 
-1. Validates the run UID and receives the suggestions that were tested
+1. Receives the run UID and suggestions that were tested
 1. Reads the beam images from Tiled
 1. Computes FWHM from the marginal beam profiles
 1. Returns outcome values for each suggestion
@@ -151,7 +151,7 @@ The **evaluation function** is the bridge between raw experimental data and the 
 We compute FWHM using **marginal profiles** — projecting the 2D image onto each axis by summing, then finding where the 1D profile crosses half its peak value. This approach is robust to noise and dead pixels (they get averaged out in the projection) and doesn't require curve fitting.
 
 ```{code-cell} ipython3
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 class DetectorEvaluation(EvaluationFunction):
     def __init__(self, tiled_client: Container):
@@ -222,9 +222,7 @@ class DetectorEvaluation(EvaluationFunction):
 
         return float(fwhm), float(intensity)
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
-        if not isinstance(uid, str):
-            raise TypeError(f"DetectorEvaluation requires a Bluesky run UID string, got {uid!r}")
+    def __call__(self, uid: str, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         outcomes = []
         run = self.tiled_client[uid]
 

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, cast
 
 import bluesky.preprocessors as bpp
 from ax import Client, TOutcome, TParameterization
@@ -23,6 +23,7 @@ from ..protocols import (
     EvaluationFunction,
     OptimizationProblem,
     Sensor,
+    TUid,
 )
 from ..utils import InferredReadable
 from .dof import DOF, DOFConstraint
@@ -30,7 +31,6 @@ from .objective import Objective, OutcomeConstraint, ScalarizedObjective, to_ax_
 from .optimizer import AxOptimizer
 
 logger = logging.getLogger(__name__)
-TUid = TypeVar("TUid")
 
 
 class _AxAgentMixin:

--- a/src/blop/ax/agent.py
+++ b/src/blop/ax/agent.py
@@ -1,8 +1,8 @@
 """Agent interface for optimization with Ax as the backend."""
 
 import logging
-from collections.abc import Hashable, Mapping, Sequence
-from typing import Any, cast
+from collections.abc import Mapping, Sequence
+from typing import Any, Generic, TypeVar, cast
 
 import bluesky.preprocessors as bpp
 from ax import Client, TOutcome, TParameterization
@@ -30,6 +30,7 @@ from .objective import Objective, OutcomeConstraint, ScalarizedObjective, to_ax_
 from .optimizer import AxOptimizer
 
 logger = logging.getLogger(__name__)
+TAcquisition = TypeVar("TAcquisition")
 
 
 class _AxAgentMixin:
@@ -200,7 +201,7 @@ class _AxAgentMixin:
         self._optimizer.reconfigure_search_space({dof.parameter_name: update for dof, update in dof_mappings.items()})
 
 
-class Agent(_AxAgentMixin):
+class Agent(_AxAgentMixin, Generic[TAcquisition]):
     """
     An interface that uses Ax as the backend for optimization and experiment tracking.
 
@@ -255,8 +256,8 @@ class Agent(_AxAgentMixin):
         sensors: Sequence[Sensor],
         dofs: Sequence[DOF],
         objectives: Sequence[Objective] | ScalarizedObjective,
-        evaluation_function: EvaluationFunction,
-        acquisition_plan: AcquisitionPlan | None = None,
+        evaluation_function: EvaluationFunction[TAcquisition],
+        acquisition_plan: AcquisitionPlan[TAcquisition] | None = None,
         dof_constraints: Sequence[DOFConstraint] | None = None,
         outcome_constraints: Sequence[OutcomeConstraint] | None = None,
         checkpoint_path: str | None = None,
@@ -293,9 +294,9 @@ class Agent(_AxAgentMixin):
         checkpoint_path: str,
         actuators: Sequence[Actuator],
         sensors: Sequence[Sensor],
-        evaluation_function: EvaluationFunction,
-        acquisition_plan: AcquisitionPlan | None = None,
-    ) -> "Agent":
+        evaluation_function: EvaluationFunction[TAcquisition],
+        acquisition_plan: AcquisitionPlan[TAcquisition] | None = None,
+    ) -> "Agent[TAcquisition]":
         """
         Load an agent from the optimizer's checkpoint file.
 
@@ -386,16 +387,16 @@ class Agent(_AxAgentMixin):
         return self._actuators
 
     @property
-    def evaluation_function(self) -> EvaluationFunction:
+    def evaluation_function(self) -> EvaluationFunction[TAcquisition]:
         """The function used to evaluate acquired data and produce outcomes."""
         return self._evaluation_function
 
     @property
-    def acquisition_plan(self) -> AcquisitionPlan | None:
+    def acquisition_plan(self) -> AcquisitionPlan[TAcquisition] | None:
         """The acquisition plan for acquiring data, or ``None`` if using the default."""
         return self._acquisition_plan
 
-    def to_optimization_problem(self) -> OptimizationProblem:
+    def to_optimization_problem(self) -> OptimizationProblem[TAcquisition]:
         """
         Construct an optimization problem from the agent.
 
@@ -499,7 +500,7 @@ class Agent(_AxAgentMixin):
 
     def sample_suggestions(
         self, suggestions: Sequence[Mapping]
-    ) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
+    ) -> MsgGenerator[tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]]:
         """
         Evaluate specific parameter combinations.
 
@@ -513,8 +514,8 @@ class Agent(_AxAgentMixin):
 
         Returns
         -------
-        tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]
-            Acquisition identifier, suggestions with "_id", and outcomes.
+        tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]
+            Acquisition UID, suggestions with "_id", and outcomes.
 
         See Also
         --------

--- a/src/blop/ax/queueserver_agent.py
+++ b/src/blop/ax/queueserver_agent.py
@@ -81,7 +81,7 @@ class QueueserverAgent(_AxAgentMixin):
         sensors: Sequence[str],
         dofs: Sequence[DOF],
         objectives: Sequence[Objective],
-        evaluation_function: EvaluationFunction,
+        evaluation_function: EvaluationFunction[str],
         acquisition_plan: str | None = None,
         dof_constraints: Sequence[DOFConstraint] | None = None,
         outcome_constraints: Sequence[OutcomeConstraint] | None = None,
@@ -116,7 +116,7 @@ class QueueserverAgent(_AxAgentMixin):
         )
 
     @property
-    def evaluation_function(self) -> EvaluationFunction:
+    def evaluation_function(self) -> EvaluationFunction[str]:
         """Evaluation function mapping acquired data to outcomes."""
         return self._evaluation_function
 

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -1,10 +1,8 @@
 """Bluesky plan stubs for optimization."""
 
-import json
 import logging
 from collections import defaultdict
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
-from dataclasses import asdict, is_dataclass
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
@@ -39,27 +37,10 @@ def _is_array_like_identifier(uid: Any) -> bool:
     return numpy_array.dtype != object
 
 
-def _json_serialized_mapping(uid: Any) -> str | None:
-    """Return a canonical JSON string for mapping or dataclass UIDs, if possible."""
-    if isinstance(uid, Mapping):
-        candidate = dict(uid)
-    elif is_dataclass(uid) and not isinstance(uid, type):
-        candidate = asdict(uid)
-    else:
-        return None
-
-    try:
-        return json.dumps(candidate, allow_nan=False, separators=(",", ":"), sort_keys=True)
-    except (TypeError, ValueError):
-        return None
-
-
 def _acquisition_identifier_value(uid: Any) -> Any:
     """Convert an acquisition UID to an event-readable value."""
     if _is_array_like_identifier(uid):
         return cast(ArrayLike, uid)
-    if (json_uid := _json_serialized_mapping(uid)) is not None:
-        return json_uid
     return repr(uid)
 
 
@@ -98,8 +79,8 @@ def read_step(
     If fewer suggestions are returned than n_points arrays are padded to n_points length
     with np.nan to ensure consistent shapes for event-model specification.
 
-    The emitted ``acquisition_uid`` field retains native array-like identifiers. Mapping and dataclass UIDs
-    that serialize to JSON are stored as canonical JSON strings; other UIDs are represented by ``repr(uid)``.
+    The emitted ``acquisition_uid`` field retains native array-like identifiers.
+    Other acquisition UIDs are represented by ``repr(uid)``.
 
     Parameters
     ----------

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -39,8 +39,8 @@ def _is_array_like_identifier(uid: Any) -> bool:
     return numpy_array.dtype != object
 
 
-def _json_serializable_dict(uid: Any) -> dict[str, Any] | None:
-    """Return a JSON-compatible dict for mapping or dataclass UIDs, if possible."""
+def _json_serialized_mapping(uid: Any) -> str | None:
+    """Return a canonical JSON string for mapping or dataclass UIDs, if possible."""
     if isinstance(uid, Mapping):
         candidate = dict(uid)
     elif is_dataclass(uid) and not isinstance(uid, type):
@@ -49,7 +49,7 @@ def _json_serializable_dict(uid: Any) -> dict[str, Any] | None:
         return None
 
     try:
-        return json.loads(json.dumps(candidate, allow_nan=False))
+        return json.dumps(candidate, allow_nan=False, separators=(",", ":"), sort_keys=True)
     except (TypeError, ValueError):
         return None
 
@@ -58,8 +58,8 @@ def _acquisition_identifier_value(uid: Any) -> Any:
     """Convert an acquisition UID to an event-readable value."""
     if _is_array_like_identifier(uid):
         return cast(ArrayLike, uid)
-    if (json_dict := _json_serializable_dict(uid)) is not None:
-        return json_dict
+    if (json_uid := _json_serialized_mapping(uid)) is not None:
+        return json_uid
     return repr(uid)
 
 
@@ -99,7 +99,7 @@ def read_step(
     with np.nan to ensure consistent shapes for event-model specification.
 
     The emitted ``acquisition_uid`` field retains native array-like identifiers. Mapping and dataclass UIDs
-    that serialize to JSON are stored as dictionaries; other UIDs are represented by ``repr(uid)``.
+    that serialize to JSON are stored as canonical JSON strings; other UIDs are represented by ``repr(uid)``.
 
     Parameters
     ----------

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -31,7 +31,7 @@ _ACQUISITION_UID_KEY: Literal["acquisition_uid"] = "acquisition_uid"
 _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
 
 
-def _is_array_like_identifier(uid: object) -> bool:
+def _is_array_like_identifier(uid: Any) -> bool:
     try:
         numpy_array = np.array(uid)
     except (TypeError, ValueError):
@@ -39,7 +39,7 @@ def _is_array_like_identifier(uid: object) -> bool:
     return numpy_array.dtype != object
 
 
-def _json_serializable_dict(uid: object) -> dict[str, Any] | None:
+def _json_serializable_dict(uid: Any) -> dict[str, Any] | None:
     """Return a JSON-compatible dict for mapping or dataclass UIDs, if possible."""
     if isinstance(uid, Mapping):
         candidate = dict(uid)
@@ -54,7 +54,7 @@ def _json_serializable_dict(uid: object) -> dict[str, Any] | None:
         return None
 
 
-def _acquisition_identifier_value(uid: object) -> Any:
+def _acquisition_identifier_value(uid: Any) -> Any:
     """Convert an acquisition UID to an event-readable value."""
     if _is_array_like_identifier(uid):
         return cast(ArrayLike, uid)
@@ -86,7 +86,7 @@ def seq_read(readables: Sequence[Readable], **kwargs: Any) -> MsgGenerator[dict[
 
 @plan
 def read_step(
-    uid: object,
+    uid: Any,
     suggestions: Sequence[Mapping],
     outcomes: Sequence[Mapping],
     n_points: int,
@@ -103,7 +103,7 @@ def read_step(
 
     Parameters
     ----------
-    uid : object
+    uid : Any
         The acquisition UID returned by the acquisition plan.
     suggestions : Sequence[Mapping]
         Sequence of suggestion mappings, each containing an ID_KEY.

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -1,8 +1,10 @@
 """Bluesky plan stubs for optimization."""
 
+import json
 import logging
 from collections import defaultdict
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
+from dataclasses import asdict, is_dataclass
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
@@ -29,7 +31,7 @@ _ACQUISITION_UID_KEY: Literal["acquisition_uid"] = "acquisition_uid"
 _SUGGESTION_IDS_KEY: Literal["suggestion_ids"] = "suggestion_ids"
 
 
-def _is_array_like_identifier(uid: Hashable) -> bool:
+def _is_array_like_identifier(uid: object) -> bool:
     try:
         numpy_array = np.array(uid)
     except (TypeError, ValueError):
@@ -37,10 +39,27 @@ def _is_array_like_identifier(uid: Hashable) -> bool:
     return numpy_array.dtype != object
 
 
-def _acquisition_identifier_value(uid: Hashable) -> ArrayLike:
-    """Convert a hashable acquisition identifier to an event-readable value."""
+def _json_serializable_dict(uid: object) -> dict[str, Any] | None:
+    """Return a JSON-compatible dict for mapping or dataclass UIDs, if possible."""
+    if isinstance(uid, Mapping):
+        candidate = dict(uid)
+    elif is_dataclass(uid) and not isinstance(uid, type):
+        candidate = asdict(uid)
+    else:
+        return None
+
+    try:
+        return json.loads(json.dumps(candidate, allow_nan=False))
+    except (TypeError, ValueError):
+        return None
+
+
+def _acquisition_identifier_value(uid: object) -> Any:
+    """Convert an acquisition UID to an event-readable value."""
     if _is_array_like_identifier(uid):
         return cast(ArrayLike, uid)
+    if (json_dict := _json_serializable_dict(uid)) is not None:
+        return json_dict
     return repr(uid)
 
 
@@ -67,7 +86,7 @@ def seq_read(readables: Sequence[Readable], **kwargs: Any) -> MsgGenerator[dict[
 
 @plan
 def read_step(
-    uid: Hashable,
+    uid: object,
     suggestions: Sequence[Mapping],
     outcomes: Sequence[Mapping],
     n_points: int,
@@ -79,13 +98,13 @@ def read_step(
     If fewer suggestions are returned than n_points arrays are padded to n_points length
     with np.nan to ensure consistent shapes for event-model specification.
 
-    The emitted ``acquisition_uid`` field retains native array-like identifiers.
-    Other hashable identifiers are represented by ``repr(uid)``.
+    The emitted ``acquisition_uid`` field retains native array-like identifiers. Mapping and dataclass UIDs
+    that serialize to JSON are stored as dictionaries; other UIDs are represented by ``repr(uid)``.
 
     Parameters
     ----------
-    uid : Hashable
-        The acquisition identifier returned by the acquisition plan.
+    uid : object
+        The acquisition UID returned by the acquisition plan.
     suggestions : Sequence[Mapping]
         Sequence of suggestion mappings, each containing an ID_KEY.
     outcomes : Sequence[Mapping]
@@ -146,7 +165,7 @@ def read_step(
         )
     else:
         readable_cache[_SUGGESTION_IDS_KEY].update(sorted_sids)
-    # Need to normalize the value here since `Hashable` is very broad
+    # Normalize the acquisition UID for event-model storage.
     normalized_uid = _acquisition_identifier_value(uid)
     if _ACQUISITION_UID_KEY not in readable_cache:
         readable_cache[_ACQUISITION_UID_KEY] = InferredReadable(

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -1,9 +1,9 @@
 """Bluesky plans for optimization."""
 
 import logging
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from itertools import count
-from typing import Any, Literal, cast
+from typing import Any, Literal, TypeVar, cast
 
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
@@ -13,9 +13,9 @@ from bluesky.utils import MsgGenerator, plan
 from .plan_stubs import list_scan_in_run, read_step, seq_read
 from .protocols import (
     ID_KEY,
+    AcquisitionPlan,
     Actuator,
     CanRegisterSuggestions,
-    EvaluationFunction,
     OptimizationProblem,
     Sensor,
     SupportsStoppingCriteria,
@@ -39,6 +39,9 @@ SAMPLE_SUGGESTIONS_RUN_KEY: Literal["sample_suggestions"] = "sample_suggestions"
 OPTIMIZE_RUN_KEY: Literal["optimize"] = "optimize"
 OPTIMIZE_IN_RUN_KEY: Literal["optimize_in_run"] = "optimize_in_run"
 OPTIMIZE_IN_RUN_TRACKING_STREAM: Literal["optimization"] = "optimization"
+
+
+TAcquisition = TypeVar("TAcquisition")
 
 
 @plan
@@ -116,11 +119,11 @@ def default_acquire(
 
 @plan
 def optimize_step(
-    optimization_problem: OptimizationProblem,
+    optimization_problem: OptimizationProblem[TAcquisition],
     n_points: int = 1,
     *args: Any,
     **kwargs: Any,
-) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
+) -> MsgGenerator[tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]]:
     """
     Single step of the optimization loop.
 
@@ -133,11 +136,11 @@ def optimize_step(
 
     Returns
     -------
-    tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]
-        The acquisition identifier, suggestions, and outcomes of the step.
+    tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]
+        The acquisition UID, suggestions, and outcomes of the step.
     """
     if optimization_problem.acquisition_plan is None:
-        acquisition_plan = default_acquire
+        acquisition_plan = cast(AcquisitionPlan[TAcquisition], default_acquire)
     else:
         acquisition_plan = optimization_problem.acquisition_plan
     optimizer = optimization_problem.optimizer
@@ -146,8 +149,7 @@ def optimize_step(
     _validate_suggestions(suggestions)
     try:
         uid = yield from acquisition_plan(suggestions, actuators, optimization_problem.sensors, *args, **kwargs)
-        evaluation_function: EvaluationFunction = optimization_problem.evaluation_function
-        outcomes = evaluation_function(uid, suggestions)
+        outcomes = optimization_problem.evaluation_function(uid, suggestions)
     except Exception:
         if isinstance(optimizer, TrialFaultAware):
             optimizer.register_failures(suggestions)
@@ -161,7 +163,7 @@ def optimize_step(
 
 @plan
 def optimize(
-    optimization_problem: OptimizationProblem,
+    optimization_problem: OptimizationProblem[TAcquisition],
     iterations: int | None = 1,
     n_points: int = 1,
     checkpoint_interval: int | None = None,
@@ -249,7 +251,7 @@ def optimize(
 
 @plan
 def optimize_in_run(
-    optimization_problem: OptimizationProblem,
+    optimization_problem: OptimizationProblem[TAcquisition],
     iterations: int = 1,
     n_points: int = 1,
     checkpoint_interval: int | None = None,
@@ -296,7 +298,11 @@ def optimize_in_run(
 
     optimizer = optimization_problem.optimizer
     actuators = optimization_problem.actuators
-    acquisition_plan = optimization_problem.acquisition_plan or list_scan_in_run
+    acquisition_plan = (
+        cast(AcquisitionPlan[TAcquisition], list_scan_in_run)
+        if optimization_problem.acquisition_plan is None
+        else optimization_problem.acquisition_plan
+    )
 
     @bpp.set_run_key_decorator(OPTIMIZE_IN_RUN_KEY)
     @bpp.run_decorator(md=_md)
@@ -341,11 +347,11 @@ def optimize_in_run(
 
 @plan
 def sample_suggestions(
-    optimization_problem: OptimizationProblem,
+    optimization_problem: OptimizationProblem[TAcquisition],
     suggestions: Sequence[Mapping],
     readable_cache: dict[str, InferredReadable] | None = None,
     **kwargs: Any,
-) -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
+) -> MsgGenerator[tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]]:
     """
     Evaluate specific parameter combinations.
 
@@ -370,8 +376,8 @@ def sample_suggestions(
 
     Returns
     -------
-    uid : Hashable
-        The acquisition identifier returned by the acquisition plan.
+    uid : TAcquisition
+        The acquisition UID returned by the acquisition plan.
     suggestions : Sequence[Mapping]
         Suggestions with "_id" keys.
     outcomes : Sequence[Mapping]
@@ -411,11 +417,11 @@ def sample_suggestions(
 
     @bpp.set_run_key_decorator(SAMPLE_SUGGESTIONS_RUN_KEY)
     @bpp.run_decorator(md=_md)
-    def _inner_sample_suggestions() -> MsgGenerator[tuple[Hashable, Sequence[Mapping], Sequence[Mapping]]]:
+    def _inner_sample_suggestions() -> MsgGenerator[tuple[TAcquisition, Sequence[Mapping], Sequence[Mapping]]]:
 
         # Acquire data, evaluate, and ingest outcomes
         if optimization_problem.acquisition_plan is None:
-            acquisition_plan = default_acquire
+            acquisition_plan = cast(AcquisitionPlan[TAcquisition], default_acquire)
         else:
             acquisition_plan = optimization_problem.acquisition_plan
         uid = yield from acquisition_plan(
@@ -433,7 +439,7 @@ def sample_suggestions(
 
 
 def acquire_baseline(
-    optimization_problem: OptimizationProblem,
+    optimization_problem: OptimizationProblem[TAcquisition],
     parameterization: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> MsgGenerator[None]:
@@ -464,7 +470,7 @@ def acquire_baseline(
         parameterization_copy[ID_KEY] = "baseline"
     optimizer = optimization_problem.optimizer
     if optimization_problem.acquisition_plan is None:
-        acquisition_plan = default_acquire
+        acquisition_plan = cast(AcquisitionPlan[TAcquisition], default_acquire)
     else:
         acquisition_plan = optimization_problem.acquisition_plan
     uid = yield from acquisition_plan([parameterization_copy], actuators, optimization_problem.sensors, **kwargs)

--- a/src/blop/plans.py
+++ b/src/blop/plans.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Mapping, Sequence
 from itertools import count
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, Literal, cast
 
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
@@ -20,6 +20,7 @@ from .protocols import (
     Sensor,
     SupportsStoppingCriteria,
     TrialFaultAware,
+    TUid,
 )
 from .utils import (
     InferredReadable,
@@ -39,9 +40,6 @@ SAMPLE_SUGGESTIONS_RUN_KEY: Literal["sample_suggestions"] = "sample_suggestions"
 OPTIMIZE_RUN_KEY: Literal["optimize"] = "optimize"
 OPTIMIZE_IN_RUN_KEY: Literal["optimize_in_run"] = "optimize_in_run"
 OPTIMIZE_IN_RUN_TRACKING_STREAM: Literal["optimization"] = "optimization"
-
-
-TUid = TypeVar("TUid")
 
 
 @plan

--- a/src/blop/protocols.py
+++ b/src/blop/protocols.py
@@ -1,6 +1,6 @@
 """Protocols that bridge between optimizer backends and Bluesky."""
 
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Literal, Protocol, TypeVar, runtime_checkable
 
@@ -32,6 +32,12 @@ TSensor = TypeVar("TSensor")
 """Sensor generic type"""
 TPlan = TypeVar("TPlan")
 """Plan generic type"""
+TAcquisition = TypeVar("TAcquisition")
+"""Acquisition UID generic type"""
+TAcquisition_contra = TypeVar("TAcquisition_contra", contravariant=True)
+"""Acquisition UID input type"""
+TAcquisition_co = TypeVar("TAcquisition_co", covariant=True)
+"""Acquisition UID output type"""
 
 
 @runtime_checkable
@@ -184,7 +190,7 @@ class Optimizer(Protocol):
 
 
 @runtime_checkable
-class EvaluationFunction(Protocol):
+class EvaluationFunction(Protocol[TAcquisition_contra]):
     """
     A protocol for transforming acquired data into measurable outcomes.
 
@@ -199,8 +205,10 @@ class EvaluationFunction(Protocol):
     Notes
     -----
     The evaluation function is called after data acquisition to compute outcomes.
-    It uses the acquisition identifier returned by the acquisition plan to retrieve
-    the relevant data and computes objective values and metrics for each suggestion.
+    It uses the uid returned by the acquisition plan to retrieve or identify
+    the relevant data and computes objective values and metrics for each
+    suggestion. The uid type is evaluator-defined; it may be a Bluesky run UID,
+    ordered suggestion IDs, event UIDs, or a backend-specific object.
 
     Examples
     --------
@@ -208,15 +216,14 @@ class EvaluationFunction(Protocol):
     :doc:`/tutorials/simple-experiment`
     """
 
-    def __call__(self, uid: Hashable, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
+    def __call__(self, uid: TAcquisition_contra, suggestions: Sequence[Mapping]) -> Sequence[Mapping]:
         """
         Evaluate the acquired data and produce outcomes.
 
         Parameters
         ----------
-        uid: Hashable
-            The acquisition identifier returned by the acquisition plan. This may be a Bluesky run UID,
-            a tuple of suggestion IDs in executed order, a tuple of event UIDs, or another hashable lookup key.
+        uid: TAcquisition_contra
+            The acquisition UID returned by the acquisition plan.
         suggestions: Sequence[Mapping]
             A sequence of mappings, each containing the optimizer-provided parameterization of a point to evaluate.
             This sequence is not guaranteed to be in acquisition order. Match data and outcomes by "_id".
@@ -231,7 +238,7 @@ class EvaluationFunction(Protocol):
 
 
 @runtime_checkable
-class AcquisitionPlan(Protocol):
+class AcquisitionPlan(Protocol[TAcquisition_co]):
     """
     A protocol for custom data acquisition plans.
 
@@ -250,8 +257,8 @@ class AcquisitionPlan(Protocol):
     Notes
     -----
     The acquisition plan is a Bluesky plan that should move the actuators to each
-    suggested position, acquire data from the sensors, and return a hashable
-    identifier that the evaluation function can use to retrieve the acquired data.
+    suggested position, acquire data from the sensors, and return a uid that the
+    evaluation function can use to retrieve or identify the acquired data.
     """
 
     @plan
@@ -261,13 +268,13 @@ class AcquisitionPlan(Protocol):
         actuators: Sequence[Actuator],
         sensors: Sequence[Sensor] | None = None,
         md: Mapping[str, Any] | None = None,
-    ) -> MsgGenerator[Hashable]:
+    ) -> MsgGenerator[TAcquisition_co]:
         """
         Acquire data for optimization.
 
         This should be a Bluesky plan that moves the actuators to each of their suggested positions
         and acquires data from the sensors. Suggestions may be re-ordered for more efficient acquisition,
-        but it is the responsibility of the implementer to return an identifier that lets the matching
+        but it is the responsibility of the implementer to return a uid that lets the matching
         evaluation function correlate acquired data with suggestion IDs.
 
         Parameters
@@ -285,15 +292,15 @@ class AcquisitionPlan(Protocol):
 
         Returns
         -------
-        Hashable
-            The identifier passed unchanged to the evaluation function. Examples include a Bluesky run UID,
-            a tuple of suggestion IDs in executed order, a tuple of event UIDs, or another hashable lookup key.
+        TAcquisition_co
+            The uid passed unchanged to the evaluation function. Examples include a Bluesky run UID,
+            ordered suggestion IDs, event UIDs, or a backend-specific acquisition object.
         """
         ...
 
 
 @dataclass(frozen=True)
-class BaseOptimizationProblem(Generic[TActuator, TSensor, TPlan]):
+class BaseOptimizationProblem(Generic[TActuator, TSensor, TAcquisition, TPlan]):
     """Base class for optimization problem definitions.
 
     Provides the common structure shared by all optimization problem types.
@@ -309,12 +316,14 @@ class BaseOptimizationProblem(Generic[TActuator, TSensor, TPlan]):
     optimizer: Optimizer
     actuators: Sequence[TActuator]
     sensors: Sequence[TSensor]
-    evaluation_function: EvaluationFunction
+    evaluation_function: EvaluationFunction[TAcquisition]
     acquisition_plan: TPlan | None = None
 
 
 @dataclass(frozen=True)
-class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionPlan]):
+class OptimizationProblem(
+    BaseOptimizationProblem[Actuator, Sensor, TAcquisition, AcquisitionPlan[TAcquisition]], Generic[TAcquisition]
+):
     """
     An optimization problem to solve. Immutable once initialized.
 
@@ -331,9 +340,9 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
         A subset of the actuators' names must match the names of suggested parameterizations.
     sensors: Sequence[Sensor]
         Objects that can produce data to acquire data from the beamline using the Bluesky RunEngine.
-    evaluation_function: EvaluationFunction
-        A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
-    acquisition_plan: AcquisitionPlan, optional
+    evaluation_function: EvaluationFunction[TAcquisition]
+        A callable that uses an acquisition UID to retrieve acquired data and produce outcomes.
+    acquisition_plan: AcquisitionPlan[TAcquisition], optional
         A Bluesky plan to acquire data from the beamline. If not provided, a default plan will be used.
 
     See Also
@@ -346,7 +355,7 @@ class OptimizationProblem(BaseOptimizationProblem[Actuator, Sensor, AcquisitionP
 
 
 @dataclass(frozen=True)
-class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
+class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str, str]):
     """
     An optimization problem to solve. Immutable once initialized.
 
@@ -365,8 +374,8 @@ class QueueserverOptimizationProblem(BaseOptimizationProblem[str, str, str]):
         A subset of the actuators' names must match the names of suggested parameterizations.
     sensors: Sequence[str]
         Names of objects that can produce data to acquire data from the beamline using the Bluesky RunEngine.
-    evaluation_function: EvaluationFunction
-        A callable that uses an acquisition identifier to retrieve acquired data and produce outcomes.
+    evaluation_function: EvaluationFunction[str]
+        A callable that uses a Bluesky run UID to retrieve acquired data and produce outcomes.
     acquisition_plan: str, optional
         The name of a Bluesky plan to acquire data. If not provided, a default plan name will be used.
         The plan must match the arguments of :class:`AcquisitionPlan`.

--- a/src/blop/scipy/scipy.py
+++ b/src/blop/scipy/scipy.py
@@ -1,7 +1,7 @@
 """Scipy optimization power class for fast start QOL and Ax like agent behavior."""
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, cast
 
 import bluesky.preprocessors as bpp
 from bluesky.callbacks import CallbackBase
@@ -15,13 +15,12 @@ from blop.protocols import (
     EvaluationFunction,
     OptimizationProblem,
     Sensor,
+    TUid,
 )
 from blop.scipy.configs import SCP, Objective, RangeDOF, ScipyCFG
 from blop.scipy.inverter import InteractiveOptimizer
 from blop.scipy.normalizers import SHGO, DualAnnealing, Minimize
 from blop.utils import InferredReadable
-
-TUid = TypeVar("TUid")
 
 
 class Scipy(Generic[TUid]):

--- a/src/blop/scipy/scipy.py
+++ b/src/blop/scipy/scipy.py
@@ -1,7 +1,7 @@
 """Scipy optimization power class for fast start QOL and Ax like agent behavior."""
 
 from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import Any, Generic, TypeVar, cast
 
 import bluesky.preprocessors as bpp
 from bluesky.callbacks import CallbackBase
@@ -21,8 +21,10 @@ from blop.scipy.inverter import InteractiveOptimizer
 from blop.scipy.normalizers import SHGO, DualAnnealing, Minimize
 from blop.utils import InferredReadable
 
+TAcquisition = TypeVar("TAcquisition")
 
-class Scipy:
+
+class Scipy(Generic[TAcquisition]):
     """
     A convenience interface associated with running optimizations with Scipy, providing similar syntax to the Ax Agent
     (allowing drop in swapping as much as possible).
@@ -34,8 +36,8 @@ class Scipy:
         self,
         sensors: Sequence[Sensor],
         config: ScipyCFG,
-        evaluation_function: EvaluationFunction,
-        acquisition_plan: AcquisitionPlan | None = None,
+        evaluation_function: EvaluationFunction[TAcquisition],
+        acquisition_plan: AcquisitionPlan[TAcquisition] | None = None,
         **kwargs: Any,
     ):
         if config.optimizer not in list(SCP):
@@ -68,8 +70,8 @@ class Scipy:
         sensors: Sequence[Sensor],
         dofs: Sequence[RangeDOF],
         objectives: Sequence[Objective],
-        evaluation_function: EvaluationFunction,
-        acquisition_plan: AcquisitionPlan | None = None,
+        evaluation_function: EvaluationFunction[TAcquisition],
+        acquisition_plan: AcquisitionPlan[TAcquisition] | None = None,
         optimizer: SCP = SCP.Default,
         # dof_constraints: Sequence[DOFConstraint] | None = None,  #implemented in future iterations? make to match ax?
         # outcome_constraints: Sequence[OutcomeConstraint] | None = None,
@@ -128,12 +130,12 @@ class Scipy:
         return self._actuators
 
     @property
-    def evaluation_function(self) -> EvaluationFunction:
+    def evaluation_function(self) -> EvaluationFunction[TAcquisition]:
         """The function used to evaluate acquired data and produce outcomes."""
         return self._evaluation_function
 
     @property
-    def acquisition_plan(self) -> AcquisitionPlan | None:
+    def acquisition_plan(self) -> AcquisitionPlan[TAcquisition] | None:
         """The acquisition plan for acquiring data, or ``None`` if using the default."""
         return self._acquisition_plan
 
@@ -182,7 +184,7 @@ class Scipy:
         """
         self._callbacks.remove(callback)
 
-    def to_optimization_problem(self) -> OptimizationProblem:
+    def to_optimization_problem(self) -> OptimizationProblem[TAcquisition]:
         """
         Construct an optimization problem from the Scipy Base class.
 

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -60,14 +60,14 @@ def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, 
 
 
 @dataclass
-class _SerializableAcquisitionUID:
+class _DataclassAcquisitionUID:
     correlation_uid: str
     item_uid: str | None
     plan_name: str
     metadata: dict[str, object]
 
 
-_SERIALIZABLE_ACQUISITION_UID = _SerializableAcquisitionUID(
+_DATACLASS_ACQUISITION_UID = _DataclassAcquisitionUID(
     correlation_uid="correlation-123",
     item_uid=None,
     plan_name="count",
@@ -76,10 +76,28 @@ _SERIALIZABLE_ACQUISITION_UID = _SerializableAcquisitionUID(
 
 
 @plan
-def _serializable_uid_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
-    """Acquisition plan that returns a JSON-serializable dataclass UID."""
+def _dataclass_uid_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns a dataclass UID."""
     yield from bps.null()
-    return _SERIALIZABLE_ACQUISITION_UID
+    return _DATACLASS_ACQUISITION_UID
+
+
+class _ArrayRejectingAcquisitionUID:
+    def __array__(self, dtype=None, copy=None):
+        raise TypeError("Not array-like")
+
+    def __repr__(self):
+        return "ArrayRejectingAcquisitionUID()"
+
+
+_ARRAY_REJECTING_ACQUISITION_UID = _ArrayRejectingAcquisitionUID()
+
+
+@plan
+def _array_rejecting_uid_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns a UID that rejects NumPy coercion."""
+    yield from bps.null()
+    return _ARRAY_REJECTING_ACQUISITION_UID
 
 
 class _UnhashableAcquisitionReference:
@@ -918,16 +936,16 @@ def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
     assert events[0]["data"]["acquisition_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
 
 
-def test_optimize_with_serializable_acquisition_uid_uses_json_string(RE):
-    """Store a JSON-serializable dataclass acquisition UID as a JSON string."""
+def test_optimize_with_dataclass_acquisition_uid_uses_repr(RE):
+    """Store a dataclass acquisition UID via its repr."""
     suggestion = {"x1": 0.5, "_id": 0}
     outcome = {"objective": 1.25, "_id": 0}
     optimizer = MagicMock(spec=Optimizer)
     optimizer.suggest.return_value = [suggestion]
     evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[outcome])
-    typed_evaluation_function = cast(EvaluationFunction[_SerializableAcquisitionUID], evaluation_function)
-    typed_acquisition_plan = cast(AcquisitionPlan[_SerializableAcquisitionUID], _serializable_uid_acquisition_plan)
-    optimization_problem: OptimizationProblem[_SerializableAcquisitionUID] = OptimizationProblem(
+    typed_evaluation_function = cast(EvaluationFunction[_DataclassAcquisitionUID], evaluation_function)
+    typed_acquisition_plan = cast(AcquisitionPlan[_DataclassAcquisitionUID], _dataclass_uid_acquisition_plan)
+    optimization_problem: OptimizationProblem[_DataclassAcquisitionUID] = OptimizationProblem(
         optimizer=optimizer,
         actuators=[MovableSignal("x1", initial_value=-1.0)],
         sensors=[ReadableSignal("objective")],
@@ -942,12 +960,35 @@ def test_optimize_with_serializable_acquisition_uid_uses_json_string(RE):
     finally:
         RE.unsubscribe(callback)
 
-    evaluation_function.assert_called_once_with(_SERIALIZABLE_ACQUISITION_UID, [suggestion])
+    evaluation_function.assert_called_once_with(_DATACLASS_ACQUISITION_UID, [suggestion])
     assert len(events) == 1
-    assert (
-        events[0]["data"]["acquisition_uid"]
-        == '{"correlation_uid":"correlation-123","item_uid":null,"metadata":{"stream":"primary"},"plan_name":"count"}'
+    assert events[0]["data"]["acquisition_uid"] == repr(_DATACLASS_ACQUISITION_UID)
+
+
+def test_optimize_with_array_rejecting_uid_uses_repr(RE):
+    """Fall back to repr when a UID rejects NumPy array coercion."""
+    suggestion = {"x1": 0.5, "_id": 0}
+    outcome = {"objective": 1.25, "_id": 0}
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [suggestion]
+    evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[outcome])
+    optimization_problem = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=evaluation_function,
+        acquisition_plan=_array_rejecting_uid_acquisition_plan,
     )
+
+    callback, events = _collect_optimize_events()
+    RE.subscribe(callback)
+    try:
+        RE(optimize(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    evaluation_function.assert_called_once_with(_ARRAY_REJECTING_ACQUISITION_UID, [suggestion])
+    assert events[0]["data"]["acquisition_uid"] == "ArrayRejectingAcquisitionUID()"
 
 
 def test_optimize_step_custom_acquisition_plan(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -918,8 +918,8 @@ def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
     assert events[0]["data"]["acquisition_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
 
 
-def test_optimize_with_serializable_acquisition_uid_uses_dict(RE):
-    """Store a JSON-serializable dataclass acquisition UID as a dictionary."""
+def test_optimize_with_serializable_acquisition_uid_uses_json_string(RE):
+    """Store a JSON-serializable dataclass acquisition UID as a JSON string."""
     suggestion = {"x1": 0.5, "_id": 0}
     outcome = {"objective": 1.25, "_id": 0}
     optimizer = MagicMock(spec=Optimizer)
@@ -944,12 +944,10 @@ def test_optimize_with_serializable_acquisition_uid_uses_dict(RE):
 
     evaluation_function.assert_called_once_with(_SERIALIZABLE_ACQUISITION_UID, [suggestion])
     assert len(events) == 1
-    assert events[0]["data"]["acquisition_uid"] == {
-        "correlation_uid": "correlation-123",
-        "item_uid": None,
-        "plan_name": "count",
-        "metadata": {"stream": "primary"},
-    }
+    assert (
+        events[0]["data"]["acquisition_uid"]
+        == '{"correlation_uid":"correlation-123","item_uid":null,"metadata":{"stream":"primary"},"plan_name":"count"}'
+    )
 
 
 def test_optimize_step_custom_acquisition_plan(RE):

--- a/src/blop/tests/test_plans.py
+++ b/src/blop/tests/test_plans.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import bluesky.plan_stubs as bps
@@ -55,6 +57,46 @@ def _custom_identifier_acquisition_plan(suggestions, actuators, sensors, *args, 
     """Acquisition plan that returns a custom hashable acquisition identifier."""
     yield from bps.null()
     return _CUSTOM_ACQUISITION_IDENTIFIER
+
+
+@dataclass
+class _SerializableAcquisitionUID:
+    correlation_uid: str
+    item_uid: str | None
+    plan_name: str
+    metadata: dict[str, object]
+
+
+_SERIALIZABLE_ACQUISITION_UID = _SerializableAcquisitionUID(
+    correlation_uid="correlation-123",
+    item_uid=None,
+    plan_name="count",
+    metadata={"stream": "primary"},
+)
+
+
+@plan
+def _serializable_uid_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns a JSON-serializable dataclass UID."""
+    yield from bps.null()
+    return _SERIALIZABLE_ACQUISITION_UID
+
+
+class _UnhashableAcquisitionReference:
+    __hash__ = None
+
+    def __repr__(self):
+        return "UnhashableAcquisitionReference()"
+
+
+_UNHASHABLE_ACQUISITION_REFERENCE = _UnhashableAcquisitionReference()
+
+
+@plan
+def _unhashable_reference_acquisition_plan(suggestions, actuators, sensors, *args, **kwargs):
+    """Acquisition plan that returns an unhashable acquisition UID."""
+    yield from bps.null()
+    return _UNHASHABLE_ACQUISITION_REFERENCE
 
 
 class StageableReadable(ReadableSignal):
@@ -151,6 +193,40 @@ def test_optimize(RE):
     assert data["x1"] == 0.0
     assert data["objective"] == 0.0
     assert data["acquisition_uid"] and isinstance(data["acquisition_uid"], str)
+
+
+def test_optimize_accepts_unhashable_acquisition_reference(RE):
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [{"x1": 0.0, "_id": 0}]
+    captured = []
+
+    def evaluation_function(uid: _UnhashableAcquisitionReference, suggestions: list[dict]) -> list[dict]:
+        captured.append(uid)
+        return [{"objective": 1.0, "_id": suggestions[0]["_id"]}]
+
+    typed_evaluation_function = cast(EvaluationFunction[_UnhashableAcquisitionReference], evaluation_function)
+    typed_acquisition_plan = cast(AcquisitionPlan[_UnhashableAcquisitionReference], _unhashable_reference_acquisition_plan)
+    optimization_problem: OptimizationProblem[_UnhashableAcquisitionReference] = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=typed_evaluation_function,
+        acquisition_plan=typed_acquisition_plan,
+    )
+
+    with pytest.raises(TypeError):
+        hash(_UNHASHABLE_ACQUISITION_REFERENCE)
+
+    callback, events = _collect_optimize_events()
+    RE.subscribe(callback)
+    try:
+        RE(optimize(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    assert captured == [_UNHASHABLE_ACQUISITION_REFERENCE]
+    optimizer.ingest.assert_called_once_with([{"objective": 1.0, "_id": 0}])
+    assert events[0]["data"]["acquisition_uid"] == repr(_UNHASHABLE_ACQUISITION_REFERENCE)
 
 
 def test_optimization_failure(RE):
@@ -840,6 +916,40 @@ def test_optimize_with_custom_hashable_acquisition_identifier_uses_repr(RE):
     evaluation_function.assert_called_once_with(_CUSTOM_ACQUISITION_IDENTIFIER, [suggestion])
     assert len(events) == 1
     assert events[0]["data"]["acquisition_uid"] == repr(_CUSTOM_ACQUISITION_IDENTIFIER)
+
+
+def test_optimize_with_serializable_acquisition_uid_uses_dict(RE):
+    """Store a JSON-serializable dataclass acquisition UID as a dictionary."""
+    suggestion = {"x1": 0.5, "_id": 0}
+    outcome = {"objective": 1.25, "_id": 0}
+    optimizer = MagicMock(spec=Optimizer)
+    optimizer.suggest.return_value = [suggestion]
+    evaluation_function = MagicMock(spec=EvaluationFunction, return_value=[outcome])
+    typed_evaluation_function = cast(EvaluationFunction[_SerializableAcquisitionUID], evaluation_function)
+    typed_acquisition_plan = cast(AcquisitionPlan[_SerializableAcquisitionUID], _serializable_uid_acquisition_plan)
+    optimization_problem: OptimizationProblem[_SerializableAcquisitionUID] = OptimizationProblem(
+        optimizer=optimizer,
+        actuators=[MovableSignal("x1", initial_value=-1.0)],
+        sensors=[ReadableSignal("objective")],
+        evaluation_function=typed_evaluation_function,
+        acquisition_plan=typed_acquisition_plan,
+    )
+
+    callback, events = _collect_optimize_events()
+    RE.subscribe(callback)
+    try:
+        RE(optimize(optimization_problem))
+    finally:
+        RE.unsubscribe(callback)
+
+    evaluation_function.assert_called_once_with(_SERIALIZABLE_ACQUISITION_UID, [suggestion])
+    assert len(events) == 1
+    assert events[0]["data"]["acquisition_uid"] == {
+        "correlation_uid": "correlation-123",
+        "item_uid": None,
+        "plan_name": "count",
+        "metadata": {"stream": "primary"},
+    }
 
 
 def test_optimize_step_custom_acquisition_plan(RE):

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -3,7 +3,7 @@
 import time
 from collections.abc import Hashable, Mapping, Sequence
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 import bluesky.preprocessors as bpp
 import networkx as nx
@@ -14,6 +14,8 @@ from event_model import DataKey
 from numpy.typing import ArrayLike
 
 from .protocols import ID_KEY, Actuator, Checkpointable, OptimizationProblem, Optimizer
+
+T = TypeVar("T")
 
 
 class Source(StrEnum):
@@ -79,11 +81,11 @@ def _validate_outcomes(outcomes: Sequence[Mapping], suggestions: Sequence[Mappin
 
 
 def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
-    """Return suggestion IDs as a hashable acquisition identifier."""
+    """Return suggestion IDs as an in-run acquisition UID."""
     return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
 
 
-def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+def _drop_run_control_messages(plan: MsgGenerator[T]) -> MsgGenerator[T]:
     """Drop child-run messages while preserving hardware lifecycle messages."""
 
     def _drop(msg: Any) -> Any | None:
@@ -94,7 +96,7 @@ def _drop_run_control_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Has
     return (yield from bpp.msg_mutator(plan, _drop))
 
 
-def _reject_child_run_messages(plan: MsgGenerator[Hashable]) -> MsgGenerator[Hashable]:
+def _reject_child_run_messages(plan: MsgGenerator[T]) -> MsgGenerator[T]:
     """Reject child-run messages inside the plan."""
 
     def _reject(msg: Any) -> Any:
@@ -117,8 +119,10 @@ def _maybe_checkpoint(optimizer: Optimizer, checkpoint_interval: int | None, ite
         optimizer.checkpoint()
 
 
-def _infer_data_key(source: Source, value: ArrayLike) -> DataKey:
+def _infer_data_key(source: Source, value: Any) -> DataKey:
     """Infer the data key from the provided value."""
+    if isinstance(value, Mapping):
+        return DataKey(source=source.value, dtype="string", shape=[])
     numpy_array = np.array(value)
     # Descriptions are cached across updates, so reserve enough space for UUIDs.
     dtype_numpy = (
@@ -191,11 +195,13 @@ class InferredReadable(Readable, HasHints, HasParent):
         """Describe the properties of this readable."""
         if not self._data_key:
             # Use stored dtype if available, otherwise infer
-            if self._dtype is not None:
-                numpy_array = np.array(self._value, dtype=self._dtype)
+            if isinstance(self._value, Mapping):
+                value = self._value
+            elif self._dtype is not None:
+                value = np.array(self._value, dtype=self._dtype)
             else:
-                numpy_array = np.array(self._value)
-            self._data_key = _infer_data_key(self._source, numpy_array)
+                value = np.array(self._value)
+            self._data_key = _infer_data_key(self._source, value)
         return {self.name: self._data_key}
 
     def update(self, value: ArrayLike) -> None:

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -119,8 +119,6 @@ def _maybe_checkpoint(optimizer: Optimizer, checkpoint_interval: int | None, ite
 
 def _infer_data_key(source: Source, value: Any) -> DataKey:
     """Infer the data key from the provided value."""
-    if isinstance(value, Mapping):
-        return DataKey(source=source.value, dtype="string", shape=[])
     numpy_array = np.array(value)
     # Descriptions are cached across updates, so reserve enough space for UUIDs.
     dtype_numpy = (
@@ -193,9 +191,7 @@ class InferredReadable(Readable, HasHints, HasParent):
         """Describe the properties of this readable."""
         if not self._data_key:
             # Use stored dtype if available, otherwise infer
-            if isinstance(self._value, Mapping):
-                value = self._value
-            elif self._dtype is not None:
+            if self._dtype is not None:
                 value = np.array(self._value, dtype=self._dtype)
             else:
                 value = np.array(self._value)

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -3,7 +3,7 @@
 import time
 from collections.abc import Hashable, Mapping, Sequence
 from enum import StrEnum
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import bluesky.preprocessors as bpp
 import networkx as nx
@@ -14,8 +14,6 @@ from event_model import DataKey
 from numpy.typing import ArrayLike
 
 from .protocols import ID_KEY, Actuator, Checkpointable, OptimizationProblem, Optimizer
-
-T = TypeVar("T")
 
 
 class Source(StrEnum):
@@ -85,7 +83,7 @@ def _suggestion_ids(suggestions: Sequence[Mapping]) -> tuple[Hashable, ...]:
     return tuple(cast(Hashable, suggestion[ID_KEY]) for suggestion in suggestions)
 
 
-def _drop_run_control_messages(plan: MsgGenerator[T]) -> MsgGenerator[T]:
+def _drop_run_control_messages(plan: MsgGenerator[Any]) -> MsgGenerator[Any]:
     """Drop child-run messages while preserving hardware lifecycle messages."""
 
     def _drop(msg: Any) -> Any | None:
@@ -96,7 +94,7 @@ def _drop_run_control_messages(plan: MsgGenerator[T]) -> MsgGenerator[T]:
     return (yield from bpp.msg_mutator(plan, _drop))
 
 
-def _reject_child_run_messages(plan: MsgGenerator[T]) -> MsgGenerator[T]:
+def _reject_child_run_messages(plan: MsgGenerator[Any]) -> MsgGenerator[Any]:
     """Reject child-run messages inside the plan."""
 
     def _reject(msg: Any) -> Any:


### PR DESCRIPTION
Assisted-by: oh-my-pi:gpt-5.5

Closes #369 

See the linked issue for the problem and why this PR was needed.

~~In addition to the issue above, I've also enabled `dict` to be inferred for `acquisition_uid` in the `read_step` plan stub. This allows you to store JSON serializable dictionaries per-event.~~

^^This wasn't a good idea and it doesn't really fit well with event-model.