### PR TITLE
Routing Decorators

### DIFF
--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -307,11 +307,7 @@ def list_scan_in_run(
     return suggestion_ids
 
 
-def preroute(
-    distance_metric: DistanceMetric,
-    *,
-    scaling: Mapping[str, float | int] | None = None,
-):
+def preroute(distance_metric: DistanceMetric, *, scaling: Mapping[str, float | int] | None = None, **cargs):
     """
     Create a Decorator for acquisition functions which helps offload route optimization for the supplied distance metric.
 
@@ -348,20 +344,20 @@ def preroute(
     return deco
 
 
-def _preroute_minkowski(exponent=2.0, scaling: Mapping[str, float | int] | None = None):
-    return preroute(partial(minkowski, exponent=exponent), scaling=scaling)
+def _preroute_minkowski(exponent=2.0, **kwargs):
+    return preroute(partial(minkowski, exponent=exponent), **kwargs)
 
 
-def _preroute_euclidean(scaling: Mapping[str, float | int] | None = None):
-    return preroute(euclidean, scaling=scaling)
+def _preroute_euclidean(**kwargs):
+    return preroute(euclidean, **kwargs)
 
 
-def _preroute_manhattan(scaling: Mapping[str, float | int] | None = None):
-    return preroute(manhattan, scaling=scaling)
+def _preroute_manhattan(**kwargs):
+    return preroute(manhattan, **kwargs)
 
 
-def _preroute_weak_chebyshev(scaling: Mapping[str, float | int] | None = None):
-    return preroute(weak_chebyshev, scaling=scaling)
+def _preroute_weak_chebyshev(**kwargs):
+    return preroute(weak_chebyshev, **kwargs)
 
 
 preroute.minkowski = _preroute_minkowski  # pyright: ignore[reportFunctionMemberAccess]

--- a/src/blop/plan_stubs.py
+++ b/src/blop/plan_stubs.py
@@ -3,6 +3,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
+from functools import partial, wraps
 from typing import Any, Literal, cast
 
 import bluesky.plan_stubs as bps
@@ -12,15 +13,20 @@ from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator, plan
 from numpy.typing import ArrayLike
 
-from .protocols import ID_KEY, Actuator, Optimizer, Sensor
+from .protocols import ID_KEY, AcquisitionPlan, Actuator, Optimizer, Sensor
 from .utils import (
+    DistanceMetric,
     InferredReadable,
     Source,
     _drop_run_control_messages,
     _suggestion_ids,
     _unpack_for_list_scan,
     _validate_suggestions,
+    euclidean,
+    manhattan,
+    minkowski,
     route_suggestions,
+    weak_chebyshev,
 )
 
 logger = logging.getLogger(__name__)
@@ -299,3 +305,66 @@ def list_scan_in_run(
     )
 
     return suggestion_ids
+
+
+def preroute(
+    distance_metric: DistanceMetric,
+    *,
+    scaling: Mapping[str, float | int] | None = None,
+):
+    """
+    Create a Decorator for acquisition functions which helps offload route optimization for the supplied distance metric.
+
+    See Also
+    --------
+    Route_suggestions
+    """  # ruff: ignore[non-imperative-mood]
+
+    def deco(f: AcquisitionPlan):
+        @wraps(f)
+        def prerouter(
+            suggestions: Sequence[Mapping],
+            actuators: Sequence[Actuator],
+            **kwargs: Any,
+        ) -> MsgGenerator[Hashable]:
+
+            if len(suggestions) > 1:
+                if all(isinstance(actuator, Readable) for actuator in actuators):
+                    current_position = yield from seq_read(cast(Sequence[Readable], actuators))
+                else:
+                    current_position = None
+
+                suggestions = route_suggestions(
+                    suggestions=suggestions,
+                    starting_position=current_position,
+                    distance_metric=distance_metric,
+                    scaling=scaling,
+                )
+
+            yield from f(suggestions, actuators, **kwargs)
+
+        return prerouter
+
+    return deco
+
+
+def _preroute_minkowski(exponent=2.0, scaling: Mapping[str, float | int] | None = None):
+    return preroute(partial(minkowski, exponent=exponent), scaling=scaling)
+
+
+def _preroute_euclidean(scaling: Mapping[str, float | int] | None = None):
+    return preroute(euclidean, scaling=scaling)
+
+
+def _preroute_manhattan(scaling: Mapping[str, float | int] | None = None):
+    return preroute(manhattan, scaling=scaling)
+
+
+def _preroute_weak_chebyshev(scaling: Mapping[str, float | int] | None = None):
+    return preroute(weak_chebyshev, scaling=scaling)
+
+
+preroute.minkowski = _preroute_minkowski  # pyright: ignore[reportFunctionMemberAccess]
+preroute.euclidean = _preroute_euclidean  # pyright: ignore[reportFunctionMemberAccess]
+preroute.manhattan = _preroute_manhattan  # pyright: ignore[reportFunctionMemberAccess]
+preroute.weak_chebyshev = _preroute_weak_chebyshev  # pyright: ignore[reportFunctionMemberAccess]

--- a/src/blop/tests/test_plan_stubs.py
+++ b/src/blop/tests/test_plan_stubs.py
@@ -70,10 +70,12 @@ def test_navigate_ignores_unknown_params(RE):
     assert x1._value == 5.0
 
 
-def test_prerouting():
-    """test that prerouting returns same spec as an evaluation function and modifies order of plan points"""
+@pytest.mark.parametrize("router", [preroute.euclidean, preroute.manhattan, preroute.weak_chebyshev])
+def test_prerouting(router):
+    """test that prerouting returns same spec as an acquisition plan and modifies order of plan points"""
     acquistion_plan = MagicMock(spec=AcquisitionPlan)
-    wrapped = preroute.euclidean()(acquistion_plan)
+    wrapped = router()(acquistion_plan)
+    assert isinstance(wrapped, AcquisitionPlan)
     x1 = MovableSignal("x1", initial_value=0.0)
     x2 = MovableSignal("x2", initial_value=0.0)
     suggestions = [{"_id": i, "x1": ((-1.1) ** i) % 1.0, "x2": ((-1.2) ** i) % 1.0} for i in range(4)]

--- a/src/blop/tests/test_plan_stubs.py
+++ b/src/blop/tests/test_plan_stubs.py
@@ -1,10 +1,11 @@
+from types import GeneratorType
 from unittest.mock import MagicMock
 
 import pytest
 from bluesky.run_engine import RunEngine
 
-from blop.plan_stubs import navigate_to_best
-from blop.protocols import Optimizer
+from blop.plan_stubs import navigate_to_best, preroute
+from blop.protocols import AcquisitionPlan, Optimizer
 
 from .conftest import MovableSignal
 
@@ -67,3 +68,17 @@ def test_navigate_ignores_unknown_params(RE):
     RE(navigate_to_best([x1], optimizer))
 
     assert x1._value == 5.0
+
+
+def test_prerouting():
+    """test that prerouting returns same spec as an evaluation function and modifies order of plan points"""
+    acquistion_plan = MagicMock(spec=AcquisitionPlan)
+    wrapped = preroute.euclidean()(acquistion_plan)
+    x1 = MovableSignal("x1", initial_value=0.0)
+    x2 = MovableSignal("x2", initial_value=0.0)
+    suggestions = [{"_id": i, "x1": ((-1.1) ** i) % 1.0, "x2": ((-1.2) ** i) % 1.0} for i in range(4)]
+    plan = wrapped(suggestions, [x1, x2])
+    assert isinstance(plan, GeneratorType)
+    [None for _ in plan]
+    order = [s["_id"] for s in acquistion_plan.call_args.args[0]]
+    assert order != [*range(4)]

--- a/src/blop/tests/test_utils.py
+++ b/src/blop/tests/test_utils.py
@@ -97,6 +97,19 @@ def test_route_suggestions_visits_each_reported_suggestion_once():
     assert set(routed_ids) == {suggestion[ID_KEY] for suggestion in suggestions}
 
 
+def test_route_suggestions_properly_scales():
+    suggestions = [
+        {ID_KEY: 0, "big_r": 0.1, "small_r": 0.5},
+        {ID_KEY: 1, "big_r": 0.0, "small_r": 1.0},
+    ]
+    start = {"big_r": 0.0, "small_r": 0.0}
+    scaling = {"big_r": 100.0, "small_r": 1.0}  # proposing big_r is a much larger and slower device than small_r
+
+    result = route_suggestions(suggestions, starting_position=start, scaling=scaling)
+    routed_ids = [suggestion[ID_KEY] for suggestion in result]
+    assert routed_ids == [1, 0]
+
+
 # _infer_data_key source value tests
 
 

--- a/src/blop/utils.py
+++ b/src/blop/utils.py
@@ -1,8 +1,9 @@
 """A set of useful helper utilities."""
 
 import time
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from enum import StrEnum
+from functools import partial
 from typing import Any, cast
 
 import bluesky.preprocessors as bpp
@@ -240,43 +241,6 @@ def _validate_route_index(index: Sequence[int], num_points: int) -> list[int]:
     return route
 
 
-def _get_route_index(points: np.ndarray, starting_point: np.ndarray | None = None) -> list[int]:
-    num_suggestions = len(points)
-    if num_suggestions < 2:
-        return list(range(num_suggestions))
-
-    graph = nx.DiGraph()
-    for i, i_point in enumerate(points):
-        for j, j_point in enumerate(points):
-            if i == j:
-                continue
-            d = np.sqrt(np.sum(np.square(i_point - j_point)))
-            graph.add_edge(i, j, weight=d)
-
-    anchor_node = num_suggestions
-    for i, point in enumerate(points):
-        d = 0.0 if starting_point is None else np.sqrt(np.sum(np.square(starting_point - point)))
-        graph.add_edge(anchor_node, i, weight=d)
-        graph.add_edge(i, anchor_node, weight=0.0)
-
-    cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", source=anchor_node, seed=0)
-    index = list(cycle[1:-1])
-
-    return _validate_route_index(index, num_suggestions)
-
-
-def route_suggestions(suggestions: Sequence[Mapping], starting_position: dict | None = None):
-    """Route suggestions through a shortest open path over routed dimensions."""
-    if len(suggestions) == 1:
-        return suggestions
-
-    dims_to_route = [dim for dim, value in suggestions[0].items() if (dim != ID_KEY) and isinstance(value, float)]
-    points = np.array([[s[dim] for dim in dims_to_route] for s in suggestions])
-    starting_point = np.array([starting_position[dim] for dim in dims_to_route]) if starting_position else None
-
-    return [suggestions[i] for i in _get_route_index(points=points, starting_point=starting_point)]
-
-
 def collect_optimization_metadata(optimization_problem: OptimizationProblem) -> dict[str, Any]:
     """Collect the metadata for the optimization problem."""
     if hasattr(optimization_problem.evaluation_function, "__name__"):
@@ -294,3 +258,51 @@ def collect_optimization_metadata(optimization_problem: OptimizationProblem) -> 
         "sensors": [sensor.name for sensor in optimization_problem.sensors],
         "actuators": [actuator.name for actuator in optimization_problem.actuators],
     }
+
+
+DistanceMetric = Callable[[np.ndarray, np.ndarray], float]
+
+
+def minkowski(a, b, exponent=2.0):
+    """Standardized minkowski distance metric upon two numpy vectors."""
+    return np.sum(np.abs(a - b) ** exponent) ** (1.0 / exponent)
+
+
+euclidean = partial(minkowski, exponent=2.0)
+manhattan = partial(minkowski, exponent=1.0)
+weak_chebyshev = partial(minkowski, exponent=10.0)
+
+
+def route_suggestions(
+    suggestions: Sequence[Mapping],
+    starting_position: dict | None = None,
+    distance_metric: DistanceMetric = euclidean,
+    scaling: Mapping[str, float | int] | None = None,
+):
+    """Route suggestions through a shortest open path over provided metric space."""
+    num_suggestions = len(suggestions)
+    if num_suggestions == 1:
+        return suggestions
+
+    scale = scaling or {}
+    dims_to_route = [dim for dim, value in suggestions[0].items() if (dim != ID_KEY) and isinstance(value, float)]
+    points = np.array([[s[dim] * scale.get(dim, 1.0) for dim in dims_to_route] for s in suggestions])
+    starting_point = np.array([starting_position[dim] for dim in dims_to_route]) if starting_position else None
+
+    graph = nx.DiGraph()
+    for i, i_point in enumerate(points):
+        for j, j_point in enumerate(points):
+            if i == j:
+                continue
+            d = distance_metric(i_point, j_point)
+            graph.add_edge(i, j, weight=d)
+
+    anchor_node = num_suggestions
+    for i, point in enumerate(points):
+        d = 0.0 if starting_point is None else distance_metric(starting_point, point)
+        graph.add_edge(anchor_node, i, weight=d)
+        graph.add_edge(i, anchor_node, weight=0.0)
+
+    cycle = nx.approximation.simulated_annealing_tsp(graph, init_cycle="greedy", source=anchor_node, seed=0)
+
+    return [suggestions[i] for i in _validate_route_index(list(cycle[1:-1]), num_suggestions)]


### PR DESCRIPTION
Draft pull request for possible implementation of #351. Plan to shift the convenience methods to use kwargs for scaling parameter as its entirely pass-through for the moment. 

Also plan to see if default acquire could be wrapped by this but i doubt it would be beneficial with it more likely to be an arbitrary distance metric and scaling passed through to default acquires route_suggestions call.